### PR TITLE
Pass coordination and compute as rest.Configs

### DIFF
--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -44,8 +44,8 @@ const (
 // Broker brokers API resources to clusters that have accepted given
 // APIs.
 type Broker struct {
-	mgr     mctrl.Manager
-	compute client.Client
+	mgr                   mctrl.Manager
+	coordination, compute client.Client
 
 	lock sync.RWMutex
 
@@ -59,11 +59,12 @@ type Broker struct {
 func NewBroker(
 	name string,
 	mgr mctrl.Manager,
-	compute client.Client,
+	coordination, compute client.Client,
 	gvks ...schema.GroupVersionKind,
 ) (*Broker, error) {
 	b := new(Broker)
 	b.mgr = mgr
+	b.coordination = coordination
 	b.compute = compute
 	b.apiAccepters = make(map[metav1.GroupVersionResource]map[string]map[string]*brokerv1alpha1.AcceptAPI)
 

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -79,13 +79,13 @@ func NewFrame(tb testing.TB) *Frame {
 
 func (f *Frame) Options(tb testing.TB) manager.Options {
 	return manager.Options{
-		Name:         tb.Name(),
-		Local:        f.Coordination.Config,
-		Compute:      f.Compute.Cluster.GetClient(),
-		Coordination: f.Coordination.Provider(),
-		Consumer:     f.Consumer.Provider(),
-		Provider:     f.Provider.Provider(),
-		MgrOptions:   ManagerOptions(),
+		Name:               tb.Name(),
+		Local:              f.Coordination.Config,
+		ComputeConfig:      f.Compute.Config,
+		CoordinationConfig: f.Coordination.Config,
+		Consumer:           f.Consumer.Provider(),
+		Provider:           f.Provider.Provider(),
+		MgrOptions:         ManagerOptions(),
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal configuration handling for compute and coordination components by transitioning from client-based to configuration-based wiring.
  * Updated configuration structure to use REST-based configurations instead of direct client instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->