### PR TITLE
Prefix provider resource names with hashed consumer cluster name to prevent conflicts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,8 @@ EXAMPLES_PREFIX ?= $(patsubst %,example-%,$(EXAMPLES))
 .PHONY: examples
 examples: $(EXAMPLES_PREFIX) ## Run the examples.
 example-%: manifests generate fmt vet
-	go run github.com/ntnn/mdextract/cmd/mdextract@main -output run.bash -tags bash,ci ./examples/$*/README.md \
+	go get github.com/ntnn/mdextract
+	go run github.com/ntnn/mdextract@main -output run.bash -tags bash,ci ./examples/$*/README.md \
 		&& trap 'rm -f run.bash' EXIT \
 		&& bash -xe ./run.bash
 

--- a/examples/certs/README.md
+++ b/examples/certs/README.md
@@ -133,16 +133,18 @@ kubectl --kubeconfig ./kubeconfigs/consumer.kubeconfig apply -f ./examples/certs
 <!--
 ```bash ci
 source ./hack/lib.bash
-kubectl::wait ./kubeconfigs/internalca.kubeconfig certificates.example.platform-mesh.io/cert-from-consumer default create
-kubectl::wait ./kubeconfigs/internalca.kubeconfig certificates.cert-manager.io/cert-from-consumer default create
-kubectl::wait ./kubeconfigs/internalca.kubeconfig certificates.cert-manager.io/cert-from-consumer default condition=Ready
+consumer_cluster="consumer#/kubeconfigs/consumer/kubeconfig+default"
+provider_cert="$(echo -n "$consumer_cluster" | sha256sum | cut -c1-12)-cert-from-consumer"
+kubectl::wait ./kubeconfigs/internalca.kubeconfig certificates.example.platform-mesh.io/$provider_cert default create
+kubectl::wait ./kubeconfigs/internalca.kubeconfig certificates.cert-manager.io/$provider_cert default create
+kubectl::wait ./kubeconfigs/internalca.kubeconfig certificates.cert-manager.io/$provider_cert default condition=Ready
 ```
 -->
 
 This will be picked up by resource-broker and sent to the InternalCA provider:
 
 ```bash ci
-kubectl --kubeconfig ./kubeconfigs/internalca.kubeconfig get certificates.example.platform-mesh.io cert-from-consumer -o yaml
+kubectl --kubeconfig ./kubeconfigs/internalca.kubeconfig get certificates.example.platform-mesh.io "$provider_cert" -o yaml
 ```
 
 ```yaml
@@ -154,7 +156,7 @@ metadata:
   - broker.platform-mesh.io/generic-finalizer
   - kro.run/finalizer
   # ...
-  name: cert-from-consumer
+  name: d480f64dc494-cert-from-consumer
   namespace: default
   # ...
 spec:
@@ -167,7 +169,7 @@ status:
         group: core
         kind: Secret
         version: v1
-      name: cert-from-consumer
+      name: d480f64dc494-cert-from-consumer
       namespace: default
   state: ACTIVE
   status: Available
@@ -186,7 +188,7 @@ items:
   kind: Certificate
   metadata:
     # ...
-    name: cert-from-consumer
+    name: d480f64dc494-cert-from-consumer
     namespace: default
     # ...
   spec:
@@ -216,7 +218,7 @@ items:
       blockOwnerDeletion: true
       controller: true
       kind: Certificate
-      name: cert-from-consumer
+      name: d480f64dc494-cert-from-consumer
       uid: f6010fea-e5b6-4be7-b6c3-b57165dc2588
     # ...
   type: kubernetes.io/tls
@@ -280,9 +282,9 @@ kubectl --kubeconfig ./kubeconfigs/consumer.kubeconfig patch certificate cert-fr
 
 <!--
 ```bash ci
-kubectl::wait ./kubeconfigs/externalca.kubeconfig certificates.example.platform-mesh.io/cert-from-consumer default create
-kubectl::wait ./kubeconfigs/externalca.kubeconfig certificates.cert-manager.io/cert-from-consumer default create
-kubectl::wait ./kubeconfigs/externalca.kubeconfig certificates.cert-manager.io/cert-from-consumer default condition=Ready
+kubectl::wait ./kubeconfigs/externalca.kubeconfig certificates.example.platform-mesh.io/$provider_cert default create
+kubectl::wait ./kubeconfigs/externalca.kubeconfig certificates.cert-manager.io/$provider_cert default create
+kubectl::wait ./kubeconfigs/externalca.kubeconfig certificates.cert-manager.io/$provider_cert default condition=Ready
 ```
 -->
 
@@ -290,8 +292,8 @@ resource-broker will first create the Certificate in the ExternalCA provider:
 
 <!--
 ```bash ci
-kubectl::wait ./kubeconfigs/externalca.kubeconfig certificates.cert-manager.io/cert-from-consumer default create
-kubectl::wait ./kubeconfigs/externalca.kubeconfig certificates.cert-manager.io/cert-from-consumer default condition=Ready
+kubectl::wait ./kubeconfigs/externalca.kubeconfig certificates.cert-manager.io/$provider_cert default create
+kubectl::wait ./kubeconfigs/externalca.kubeconfig certificates.cert-manager.io/$provider_cert default condition=Ready
 ```
 -->
 
@@ -311,7 +313,7 @@ items:
     - broker.platform-mesh.io/generic-finalizer
     - kro.run/finalizer
     # ..
-    name: cert-from-consumer
+    name: d480f64dc494-cert-from-consumer
     namespace: default
     # ..
   spec:
@@ -324,7 +326,7 @@ items:
           group: core
           kind: Secret
           version: v1
-        name: cert-from-consumer
+        name: d480f64dc494-cert-from-consumer
         namespace: default
     state: ACTIVE
     status: Available
@@ -333,7 +335,7 @@ items:
   kind: Certificate
   metadata:
     # ...
-    name: cert-from-consumer
+    name: d480f64dc494-cert-from-consumer
     namespace: default
     # ..
   spec:
@@ -364,7 +366,7 @@ items:
       blockOwnerDeletion: true
       controller: true
       kind: Certificate
-      name: cert-from-consumer
+      name: d480f64dc494-cert-from-consumer
     # ...
   type: kubernetes.io/tls
 kind: List
@@ -376,7 +378,7 @@ And then delete it from the InternalCA provider:
 
 <!--
 ```bash ci
-kubectl::wait ./kubeconfigs/internalca.kubeconfig certificates.example.platform-mesh.io/cert-from-consumer default delete
+kubectl::wait ./kubeconfigs/internalca.kubeconfig certificates.example.platform-mesh.io/$provider_cert default delete
 ```
 -->
 

--- a/examples/certs/run.bash
+++ b/examples/certs/run.bash
@@ -78,19 +78,23 @@ _stop_broker() {
 }
 
 _cleanup() {
+    local consumer_cluster
+    consumer_cluster="consumer#$(kubectl --kubeconfig "$kind_consumer" config current-context)"
+    local hash
+    hash=$(echo -n "$consumer_cluster" | sha256sum | cut -c1-12)
+    local provider_cert="${hash}-cert-from-consumer"
+
     kubectl::delete "$kind_consumer" \
         certificates.example.platform-mesh.io/cert-from-consumer \
         secret/cert-from-consumer
 
     kubectl::delete "$kind_internalca" \
-        certificates.example.platform-mesh.io/cert-from-consumer \
-        certificates.cert-manager.io/cert-from-consumer \
-        secret/cert-from-consumer
+        "certificates.example.platform-mesh.io/$provider_cert" \
+        "secret/$provider_cert"
 
     kubectl::delete "$kind_externalca" \
-        certificates.example.platform-mesh.io/cert-from-consumer \
-        certificates.cert-manager.io/cert-from-consumer \
-        secret/cert-from-consumer
+        "certificates.example.platform-mesh.io/$provider_cert" \
+        "secret/$provider_cert"
     return 0
 }
 

--- a/examples/kcp-certs/externalca/rgd.yaml
+++ b/examples/kcp-certs/externalca/rgd.yaml
@@ -48,7 +48,7 @@ spec:
           namespace: ${schema.metadata.namespace}
         spec:
           commonName: ${schema.spec.fqdn}
-          secretName: ${schema.metadata.name}
+          secretName: ${schema.metadata.?annotations["syncagent.kcp.io/remote-object-name"]}
           privateKey:
             algorithm: ECDSA
             size: 256
@@ -62,5 +62,5 @@ spec:
         apiVersion: v1
         kind: Secret
         metadata:
-          name: ${certificate.metadata.name}
+          name: ${certificate.metadata.?annotations["remote-object-name"]}
           namespace: ${certificate.metadata.namespace}

--- a/examples/kcp-certs/internalca/rgd.yaml
+++ b/examples/kcp-certs/internalca/rgd.yaml
@@ -48,7 +48,7 @@ spec:
           namespace: ${schema.metadata.namespace}
         spec:
           commonName: ${schema.spec.fqdn}
-          secretName: ${schema.metadata.name}
+          secretName: ${schema.metadata.?annotations["syncagent.kcp.io/remote-object-name"]}
           privateKey:
             algorithm: ECDSA
             size: 256
@@ -62,5 +62,5 @@ spec:
         apiVersion: v1
         kind: Secret
         metadata:
-          name: ${certificate.metadata.name}
+          name: ${certificate.metadata.?annotations["remote-object-name"]}
           namespace: ${certificate.metadata.namespace}

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
+	github.com/gomarkdown/markdown v0.0.0-20250810172220-2e2c11897d1a // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -45,6 +46,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/ntnn/mdextract v0.4.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/gomarkdown/markdown v0.0.0-20250810172220-2e2c11897d1a h1:l7A0loSszR5zHd/qK53ZIHMO8b3bBSmENnQ6eKnUT0A=
+github.com/gomarkdown/markdown v0.0.0-20250810172220-2e2c11897d1a/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/cel-go v0.27.0 h1:e7ih85+4qVrBuqQWTW4FKSqZYokVuc3HnhH5keboFTo=
@@ -93,6 +95,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/ntnn/mdextract v0.4.1 h1:W3V6NGriIBazjezKl9uSZjQCa5gX1UlNoMKoRbAQNN0=
+github.com/ntnn/mdextract v0.4.1/go.mod h1:K/lD8P/Rgzeek5VMbPNnKHfotJ0PuBaal1aC2niLgr4=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=

--- a/pkg/broker/generic/generic_test.go
+++ b/pkg/broker/generic/generic_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright The Platform Mesh Authors.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	mctrl "sigs.k8s.io/multicluster-runtime"
+)
+
+func TestSanitizeClusterName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("produces DNS-safe output", func(t *testing.T) {
+		t.Parallel()
+
+		// Cluster names can contain special characters
+		name := "consumer#/kubeconfigs/consumer/kubeconfig+default"
+		result := SanitizeClusterName(name)
+
+		assert.Regexp(t, `^[a-f0-9]{12}$`, result,
+			"sanitized name should be 12 hex characters")
+	})
+
+	t.Run("deterministic", func(t *testing.T) {
+		t.Parallel()
+
+		name := "consumer-team-a"
+		assert.Equal(t, SanitizeClusterName(name), SanitizeClusterName(name))
+	})
+
+	t.Run("different inputs produce different outputs", func(t *testing.T) {
+		t.Parallel()
+
+		assert.NotEqual(t,
+			SanitizeClusterName("consumer-team-a"),
+			SanitizeClusterName("consumer-team-b"),
+		)
+	})
+}
+
+func TestProviderNamespacedName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("prefixes hashed consumer name to resource name", func(t *testing.T) {
+		t.Parallel()
+
+		gr := &objectReconcileTask{
+			consumerName: "consumer-team-a",
+			req: mctrl.Request{
+				Request: reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: "default",
+						Name:      "my-cert",
+					},
+				},
+			},
+		}
+
+		result := gr.providerNamespacedName()
+		expected := SanitizeClusterName("consumer-team-a") + "-my-cert"
+		assert.Equal(t, expected, result.Name)
+		assert.Equal(t, "default", result.Namespace)
+	})
+
+	t.Run("namespace is preserved unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		gr := &objectReconcileTask{
+			consumerName: "consumer-eu",
+			req: mctrl.Request{
+				Request: reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: "prod-ns",
+						Name:      "db-backup",
+					},
+				},
+			},
+		}
+
+		result := gr.providerNamespacedName()
+		assert.Equal(t, "prod-ns", result.Namespace)
+	})
+
+	t.Run("uses consumerObjName when set (provider-side request)", func(t *testing.T) {
+		t.Parallel()
+
+		prefix := SanitizeClusterName("consumer-team-a")
+		gr := &objectReconcileTask{
+			consumerName: "consumer-team-a",
+			req: mctrl.Request{
+				Request: reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						// This is the prefixed name from the provider side
+						Namespace: "default",
+						Name:      prefix + "-my-cert",
+					},
+				},
+			},
+			consumerObjName: &types.NamespacedName{
+				Namespace: "default",
+				Name:      "my-cert",
+			},
+		}
+
+		result := gr.providerNamespacedName()
+		assert.Equal(t, prefix+"-my-cert", result.Name)
+		assert.Equal(t, "default", result.Namespace)
+	})
+
+	t.Run("two consumers same resource produce different provider names", func(t *testing.T) {
+		t.Parallel()
+
+		nn := types.NamespacedName{Namespace: "default", Name: "my-cert"}
+
+		grA := &objectReconcileTask{
+			consumerName: "consumer-team-a",
+			req: mctrl.Request{
+				Request: reconcile.Request{NamespacedName: nn},
+			},
+		}
+		grB := &objectReconcileTask{
+			consumerName: "consumer-team-b",
+			req: mctrl.Request{
+				Request: reconcile.Request{NamespacedName: nn},
+			},
+		}
+
+		resultA := grA.providerNamespacedName()
+		resultB := grB.providerNamespacedName()
+
+		assert.NotEqual(t, resultA.Name, resultB.Name,
+			"different consumers must produce different provider names")
+		// Namespace stays the same for both
+		assert.Equal(t, resultA.Namespace, resultB.Namespace)
+	})
+
+	t.Run("handles cluster names with special characters", func(t *testing.T) {
+		t.Parallel()
+
+		gr := &objectReconcileTask{
+			consumerName: "consumer#/kubeconfigs/consumer/kubeconfig+default",
+			req: mctrl.Request{
+				Request: reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: "default",
+						Name:      "my-cert",
+					},
+				},
+			},
+		}
+
+		result := gr.providerNamespacedName()
+		// Name should be valid DNS: only lowercase hex + dash + original name
+		assert.Regexp(t, `^[a-f0-9]{12}-my-cert$`, result.Name)
+	})
+}
+
+func TestConsumerNamespacedName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns req.NamespacedName when consumerObjName is nil", func(t *testing.T) {
+		t.Parallel()
+
+		gr := &objectReconcileTask{
+			req: mctrl.Request{
+				Request: reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: "default",
+						Name:      "my-cert",
+					},
+				},
+			},
+		}
+
+		result := gr.consumerNamespacedName()
+		assert.Equal(t, "my-cert", result.Name)
+		assert.Equal(t, "default", result.Namespace)
+	})
+
+	t.Run("returns consumerObjName when set", func(t *testing.T) {
+		t.Parallel()
+
+		gr := &objectReconcileTask{
+			req: mctrl.Request{
+				Request: reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: "default",
+						Name:      "abc123-my-cert",
+					},
+				},
+			},
+			consumerObjName: &types.NamespacedName{
+				Namespace: "default",
+				Name:      "my-cert",
+			},
+		}
+
+		result := gr.consumerNamespacedName()
+		assert.Equal(t, "my-cert", result.Name)
+		assert.Equal(t, "default", result.Namespace)
+	})
+}

--- a/test/e2e/manager_test.go
+++ b/test/e2e/manager_test.go
@@ -31,6 +31,7 @@ import (
 
 	brokerv1alpha1 "github.com/platform-mesh/resource-broker/api/broker/v1alpha1"
 	"github.com/platform-mesh/resource-broker/cmd/manager"
+	"github.com/platform-mesh/resource-broker/pkg/broker/generic"
 )
 
 // TestManagerCopy only tests that the manager can copy from a source to
@@ -92,12 +93,13 @@ func TestManagerCopy(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Wait for ConfigMap to appear in provider control plane")
+	providerCMName := generic.SanitizeClusterName("consumer#consumer#cluster") + "-" + cmName
 	require.Eventually(t, func() bool {
 		cm := &corev1.ConfigMap{}
 		err := provider.Cluster.GetClient().Get(
 			t.Context(),
 			types.NamespacedName{
-				Name:      cmName,
+				Name:      providerCMName,
 				Namespace: namespace,
 			},
 			cm,

--- a/test/e2e/migration_test.go
+++ b/test/e2e/migration_test.go
@@ -34,6 +34,7 @@ import (
 	brokerv1alpha1 "github.com/platform-mesh/resource-broker/api/broker/v1alpha1"
 	examplev1alpha1 "github.com/platform-mesh/resource-broker/api/example/v1alpha1"
 	"github.com/platform-mesh/resource-broker/cmd/manager"
+	"github.com/platform-mesh/resource-broker/pkg/broker/generic"
 )
 
 // TestMigrationNoStages tests that migrations are created and processed
@@ -155,13 +156,15 @@ func TestMigrationNoStages(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	providerVMName := generic.SanitizeClusterName("consumer#consumer#cluster") + "-" + vmName
+
 	t.Log("Wait for VM to appear in x86 provider")
 	vm := &examplev1alpha1.VM{}
 	require.Eventually(t, func() bool {
 		err := x86Provider.Cluster.GetClient().Get(
 			t.Context(),
 			types.NamespacedName{
-				Name:      vmName,
+				Name:      providerVMName,
 				Namespace: vmNamespace,
 			},
 			vm,
@@ -226,7 +229,7 @@ func TestMigrationNoStages(t *testing.T) {
 		err := armProvider.Cluster.GetClient().Get(
 			t.Context(),
 			types.NamespacedName{
-				Name:      vmName,
+				Name:      providerVMName,
 				Namespace: vmNamespace,
 			},
 			vm,
@@ -243,7 +246,7 @@ func TestMigrationNoStages(t *testing.T) {
 		err := x86Provider.Cluster.GetClient().Get(
 			t.Context(),
 			types.NamespacedName{
-				Name:      vmName,
+				Name:      providerVMName,
 				Namespace: vmNamespace,
 			},
 			vm,
@@ -399,13 +402,15 @@ func TestMigrationWithStages(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	providerVMName := generic.SanitizeClusterName("consumer#consumer#cluster") + "-" + vmName
+
 	t.Log("Wait for VM to appear in x86 provider")
 	vm := &examplev1alpha1.VM{}
 	require.Eventually(t, func() bool {
 		err := x86Provider.Cluster.GetClient().Get(
 			t.Context(),
 			types.NamespacedName{
-				Name:      vmName,
+				Name:      providerVMName,
 				Namespace: vmNamespace,
 			},
 			vm,
@@ -453,7 +458,7 @@ func TestMigrationWithStages(t *testing.T) {
 		err := armProvider.Cluster.GetClient().Get(
 			t.Context(),
 			types.NamespacedName{
-				Name:      vmName,
+				Name:      providerVMName,
 				Namespace: vmNamespace,
 			},
 			vm,
@@ -471,7 +476,7 @@ func TestMigrationWithStages(t *testing.T) {
 		err := x86Provider.Cluster.GetClient().Get(
 			t.Context(),
 			types.NamespacedName{
-				Name:      vmName,
+				Name:      providerVMName,
 				Namespace: vmNamespace,
 			},
 			vm,

--- a/test/e2e/relatedResources_test.go
+++ b/test/e2e/relatedResources_test.go
@@ -32,6 +32,7 @@ import (
 	brokerv1alpha1 "github.com/platform-mesh/resource-broker/api/broker/v1alpha1"
 	examplev1alpha1 "github.com/platform-mesh/resource-broker/api/example/v1alpha1"
 	"github.com/platform-mesh/resource-broker/cmd/manager"
+	"github.com/platform-mesh/resource-broker/pkg/broker/generic"
 )
 
 // TestRelatedResources tests that related resources are copied from
@@ -97,12 +98,13 @@ func TestRelatedResources(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Wait for VM to appear in provider control plane")
+	providerVMName := generic.SanitizeClusterName("consumer#consumer#cluster") + "-" + vmName
 	vm := &examplev1alpha1.VM{}
 	require.Eventually(t, func() bool {
 		err := provider.Cluster.GetClient().Get(
 			t.Context(),
 			types.NamespacedName{
-				Name:      vmName,
+				Name:      providerVMName,
 				Namespace: namespace,
 			},
 			vm,
@@ -111,7 +113,7 @@ func TestRelatedResources(t *testing.T) {
 			t.Logf("error getting VM from provider control plane: %v", err)
 			return false
 		}
-		return vm.Name == vmName
+		return vm.Name == providerVMName
 	}, wait.ForeverTestTimeout, time.Second)
 
 	t.Log("Create related ConfigMap in provider control plane")
@@ -138,7 +140,7 @@ func TestRelatedResources(t *testing.T) {
 		err := provider.Cluster.GetClient().Get(
 			t.Context(),
 			types.NamespacedName{
-				Name:      vmName,
+				Name:      providerVMName,
 				Namespace: namespace,
 			},
 			vm,


### PR DESCRIPTION
- Prefix provider-side resource names with a 12-char hash of the consumer cluster name to prevent conflicts when multiple consumers create resources with the same name/namespace
- Store original name in annotation for provider-to-consumer reverse lookup
- Strip prefix from related resources when syncing back to consumer
- Added unit tests for the generic functions
- Modified the e2e examples test