### PR TITLE
docs: add BMWK-EU funding notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,5 @@ The `examples/` directory contains comprehensive walkthroughs. The best place to
 ## License
 
 This project is licensed under [Apache-2.0](./LICENSE).
+
+<p align="center"><img alt="Bundesministerium für Wirtschaft und Energie (BMWE)-EU funding logo" src="https://apeirora.eu/assets/img/BMWK-EU.png" width="400"/></p>


### PR DESCRIPTION
## Summary

- Adds the required BMWK-EU funding logo/notice to the end of the README, as required for all public repositories in the organization.