### PR TITLE
Per consumer x provider staging workspaces managed by resource-broke improvements

### DIFF
--- a/api/broker/v1alpha1/stagingworkspace_types.go
+++ b/api/broker/v1alpha1/stagingworkspace_types.go
@@ -51,6 +51,9 @@ const (
 	StagingWorkspacePhaseReady StagingWorkspacePhase = "Ready"
 	// StagingWorkspacePhaseFailed indicates the staging workspace could not be provisioned.
 	StagingWorkspacePhaseFailed StagingWorkspacePhase = "Failed"
+	// StagingWorkspacePhaseTerminating indicates the staging workspace is being torn down because
+	// all resources that were using it have been deleted. No new resources will be routed to it.
+	StagingWorkspacePhaseTerminating StagingWorkspacePhase = "Terminating"
 )
 
 // StagingWorkspaceStatus defines the observed state of StagingWorkspace.

--- a/contrib/kcp/cmd/main.go
+++ b/contrib/kcp/cmd/main.go
@@ -64,7 +64,7 @@ var (
 		"APIExportEndpointSlice name to watch for APIs to broker.",
 	)
 
-	fWorkspaceTreeRoot = flag.String("workspace-tree-root", "", "kcp workspace path under which staging workspaces are created (required)")
+	fWorkspaceTreeRoot = flag.String("workspace-tree-root", "root:platform", "kcp workspace path under which staging workspaces are created")
 )
 
 func main() {
@@ -82,11 +82,6 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
-
-	if *fWorkspaceTreeRoot == "" {
-		setupLog.Error(nil, "--workspace-tree-root is required")
-		os.Exit(1)
-	}
 
 	setupLog.Info("Starting resource-broker", "version", version.Info())
 

--- a/contrib/kcp/pkg/broker/broker.go
+++ b/contrib/kcp/pkg/broker/broker.go
@@ -472,6 +472,11 @@ func New(opts Options) (*Broker, error) { //nolint:gocyclo
 			b.lock.RLock()
 			for i := range swList.Items {
 				sw := &swList.Items[i]
+				// Skip workspaces being torn down — no new CRs should be routed there.
+				if sw.Status.Phase == brokerv1alpha1.StagingWorkspacePhaseTerminating ||
+					!sw.DeletionTimestamp.IsZero() {
+					continue
+				}
 				// Label stores "."-separated form; convert back to "#"-separated for apiAccepters lookup.
 				providerCluster := strings.ReplaceAll(sw.Labels[stagingProviderClusterLabel], ".", "#")
 				acceptAPIs, ok := b.apiAccepters[gvr][providerCluster]
@@ -711,6 +716,19 @@ func New(opts Options) (*Broker, error) { //nolint:gocyclo
 			// The staging-workspace reconciler watches StagingWorkspace updates and
 			// deletes the SW once all resource finalizers are gone.
 			return b.localClient.Update(ctx, sw)
+		},
+
+		GetConsumerFromStagingCluster: func(ctx context.Context, stagingCluster string) (string, error) {
+			swList := &brokerv1alpha1.StagingWorkspaceList{}
+			if err := b.localClient.List(ctx, swList, client.MatchingLabels{
+				stagingworkspace.StagingClusterLabelKey: clusterNameToStagingLabel(stagingCluster),
+			}); err != nil {
+				return "", err
+			}
+			if len(swList.Items) == 0 {
+				return "", nil // staging workspace gone, nothing to do
+			}
+			return swList.Items[0].Spec.ConsumerCluster, nil
 		},
 	}
 

--- a/contrib/kcp/pkg/stagingworkspace/reconciler.go
+++ b/contrib/kcp/pkg/stagingworkspace/reconciler.go
@@ -240,7 +240,8 @@ func (r *Reconciler) reconcileWorkspace(ctx context.Context, req ctrl.Request) (
 
 	// If the SW was previously tracking resources (ResourceTrackedAnnotation is
 	// set) and all resource finalizers have since been removed, the broker is
-	// done with it — delete it so finalize() can clean up the kcp workspace.
+	// done with it. First move to Terminating so the broker stops routing new
+	// CRs here, then on the next reconcile trigger the actual deletion.
 	if sw.Status.Phase == brokerv1alpha1.StagingWorkspacePhaseReady &&
 		sw.Annotations[ResourceTrackedAnnotation] == "true" {
 		hasResourceFinalizer := false
@@ -251,12 +252,22 @@ func (r *Reconciler) reconcileWorkspace(ctx context.Context, req ctrl.Request) (
 			}
 		}
 		if !hasResourceFinalizer {
-			log.Info("No resource finalizers remain, deleting staging workspace", "stagingWorkspace", sw.Name)
-			if err := r.Delete(ctx, sw); err != nil && !apierrors.IsNotFound(err) {
-				return ctrl.Result{}, fmt.Errorf("failed to delete empty staging workspace: %w", err)
+			log.Info("No resource finalizers remain, marking staging workspace as Terminating", "stagingWorkspace", sw.Name)
+			sw.Status.Phase = brokerv1alpha1.StagingWorkspacePhaseTerminating
+			if err := r.Client.Status().Update(ctx, sw); err != nil {
+				return ctrl.Result{}, err
 			}
-			return ctrl.Result{}, nil
+			return ctrl.Result{Requeue: true}, nil
 		}
+	}
+
+	// Perform actual deletion once Terminating phase is set.
+	if sw.Status.Phase == brokerv1alpha1.StagingWorkspacePhaseTerminating {
+		log.Info("Deleting staging workspace in Terminating phase", "stagingWorkspace", sw.Name)
+		if err := r.Delete(ctx, sw); err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to delete terminating staging workspace: %w", err)
+		}
+		return ctrl.Result{}, nil
 	}
 
 	result, err := r.ensureWorkspace(ctx, sw)

--- a/pkg/broker/generic/generic.go
+++ b/pkg/broker/generic/generic.go
@@ -112,6 +112,13 @@ type Options struct {
 	// Called when a resource is deleted from the staging cluster.
 	// If nil, no tracking is performed.
 	UntrackResourceFromStagingWorkspace func(ctx context.Context, stagingCluster, namespace, name string) error
+
+	// GetConsumerFromStagingCluster returns the consumer cluster name for the
+	// given staging cluster. When set, consumerClusterAnn and consumerNameAnn
+	// are not written to provider-side objects; the StagingWorkspace is the
+	// authoritative source for consumer→provider mapping.
+	// If nil, annotations on the provider object are used instead.
+	GetConsumerFromStagingCluster func(ctx context.Context, stagingCluster string) (consumerCluster string, err error)
 }
 
 // SetupController creates a controller for the resource specified by GVK.
@@ -498,6 +505,29 @@ func (t *objectReconcileTask) setConsumerCluster(ctx context.Context, name strin
 }
 
 func (t *objectReconcileTask) setConsumerClusterFromProvider(ctx context.Context) error {
+	if t.opts.GetConsumerFromStagingCluster != nil {
+		t.log.Info("Determining consumer cluster from staging workspace")
+		consumerCluster, err := t.opts.GetConsumerFromStagingCluster(ctx, t.providerName)
+		if err != nil {
+			return fmt.Errorf("failed to get consumer from staging cluster %q: %w", t.providerName, err)
+		}
+		if consumerCluster == "" {
+			t.log.Info("No consumer found for staging cluster, skipping")
+			return nil
+		}
+		// Recover the original consumer resource name by stripping the
+		// deterministic hash prefix added by providerNamespacedName().
+		prefix := SanitizeClusterName(consumerCluster) + "-"
+		if stripped := strings.TrimPrefix(t.req.Name, prefix); stripped != t.req.Name {
+			t.consumerObjName = &types.NamespacedName{
+				Namespace: t.req.Namespace,
+				Name:      stripped,
+			}
+		}
+		t.log.Info("Resolved consumer from staging workspace", "consumer", consumerCluster)
+		return t.setConsumerCluster(ctx, consumerCluster)
+	}
+
 	t.log.Info("Determining consumer cluster from provider annotation")
 
 	// When the request comes from the provider side, t.req.NamespacedName
@@ -966,11 +996,16 @@ func (t *objectReconcileTask) decorateInProvider(ctx context.Context, providerNa
 			needsUpdate = true
 		}
 
-		anns := obj.GetAnnotations()
-		if anns[consumerClusterAnn] != t.consumerName || anns[consumerNameAnn] != consumerNN.Name {
-			kubernetes.SetAnnotation(obj, consumerClusterAnn, t.consumerName)
-			kubernetes.SetAnnotation(obj, consumerNameAnn, consumerNN.Name)
-			needsUpdate = true
+		// Skip consumer tracking annotations when StagingWorkspace is the
+		// authoritative source. Writing them would leak internal consumer cluster
+		// IDs onto objects that get synced to the provider's cluster by api-syncagent.
+		if t.opts.GetConsumerFromStagingCluster == nil {
+			anns := obj.GetAnnotations()
+			if anns[consumerClusterAnn] != t.consumerName || anns[consumerNameAnn] != consumerNN.Name {
+				kubernetes.SetAnnotation(obj, consumerClusterAnn, t.consumerName)
+				kubernetes.SetAnnotation(obj, consumerNameAnn, consumerNN.Name)
+				needsUpdate = true
+			}
 		}
 
 		if needsUpdate {


### PR DESCRIPTION
Implements the staging workspace lifecycle from issue [#183](https://github.com/platform-mesh/resource-broker/issues/183) — safe GC, observable teardown, and removal of broker-internal state from provider-visible resources.

- Add `StagingWorkspacePhaseTerminating`: rb sets this phase before deleting a workspace, giving one reconcile cycle where `GetStagingCluster` refuses to route new CRs there — prevents resources landing in a workspace already being torn down
- Default `--workspace-tree-root `to `root:platform` so new deployments work out of the box without a required flag
- Remove `consumerClusterAnn`/`consumerNameAnn` from staging workspace objects: these were being synced by api-syncagent to the provider's cluster, leaking consumer cluster IDs; replaced by a `StagingWorkspace` lookup via the new `GetConsumerFromStagingCluster` callback — rb no longer touches provider-visible resources at all in the kcp path, making the staging workspace the only shared surface between consumer and provider