### PR TITLE
Pin Dockerfile dependencies to hash

### DIFF
--- a/examples/platform-mesh/portal/Dockerfile
+++ b/examples/platform-mesh/portal/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
+FROM --platform=$BUILDPLATFORM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS builder
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ COPY . .
 RUN npm run build
 
 # Production stage - serve with nginx
-FROM nginx:alpine
+FROM nginx:alpine@sha256:8b1e78743a03dbb2c95171cc58639fef29abc8816598e27fb910ed2e621e589a
 
 # Copy custom nginx config
 COPY nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
As per [the latest Scorecard report](https://scorecard.dev/viewer/?uri=github.com/platform-mesh/resource-broker&sort_by=check-score&sort_direction=asc):

```
Warn: containerImage not pinned by hash: examples/platform-mesh/portal/Dockerfile:2: pin your Docker image by updating node:22-alpine to node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920
Warn: containerImage not pinned by hash: examples/platform-mesh/portal/Dockerfile:19: pin your Docker image by updating nginx:alpine to nginx:alpine@sha256:8b1e78743a03dbb2c95171cc58639fef29abc8816598e27fb910ed2e621e589a
```