### PR TITLE
cert-manager MSP provider via cert-manager + api-syncagent + resource-broker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,21 +147,21 @@ jobs:
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           file: Dockerfile
-          tags: resource-broker:dev
+          tags: localhost/resource-broker:dev
           cache-from: type=gha
           push: false
           load: true
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           file: contrib/kcp/Dockerfile
-          tags: resource-broker-kcp:dev
+          tags: localhost/resource-broker-kcp:dev
           cache-from: type=gha
           push: false
           load: true
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           file: cmd/operator/Dockerfile
-          tags: resource-broker-operator:dev
+          tags: localhost/resource-broker-operator:dev
           cache-from: type=gha
           push: false
           load: true

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Image URL to use all building/pushing image targets
-IMG ?= resource-broker:dev
-IMG_KCP ?= resource-broker-kcp:dev
-IMG_OPERATOR ?= resource-broker-operator:dev
-IMG_PORTAL ?= resource-broker-portal:dev
+IMG ?= localhost/resource-broker:dev
+IMG_KCP ?= localhost/resource-broker-kcp:dev
+IMG_OPERATOR ?= localhost/resource-broker-operator:dev
+IMG_PORTAL ?= localhost/resource-broker-portal:dev
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/config/operator/default/kustomization.yaml
+++ b/config/operator/default/kustomization.yaml
@@ -9,5 +9,5 @@ resources:
 
 images:
 - name: operator
-  newName: resource-broker-operator
-  newTag: platform-mesh
+  newName: localhost/resource-broker-operator
+  newTag: dev

--- a/examples/cert-manager-msp/README.md
+++ b/examples/cert-manager-msp/README.md
@@ -1,0 +1,402 @@
+# cert-manager MSP Provider
+
+This example wires up cert-manager as a Managed Service Provider for the
+resource-broker generic Certificate API, using
+[api-syncagent](https://docs.kcp.io/api-syncagent/main/) to bridge the
+compute cluster and kcp, and [kro](https://kro.run) to translate the generic
+`Certificate{fqdn}` into a real `cert-manager.io/Certificate`.
+
+No custom operator is written. The entire provider is declarative YAML.
+
+## Overview
+
+A consumer creates an `identity.generic.platform-mesh.io/Certificate` in their
+kcp workspace. resource-broker sees it through the platform APIExport's virtual
+workspace, matches it against the cert-manager provider's `AcceptAPI`, and routes
+it to the provider workspace. api-syncagent picks it up, creates a
+`certmanager.ca/Certificate` on the compute cluster, kro translates that into a
+real cert-manager Certificate, cert-manager signs it, and api-syncagent syncs the
+resulting TLS Secret back to the consumer workspace.
+
+```
+Consumer workspace
+  └─ Certificate{fqdn}
+        │  resource-broker routes via AcceptAPI
+        ▼
+Provider workspace (root:cert-manager)
+        │  api-syncagent watches + syncs down
+        ▼
+Compute cluster
+  ├─ certmanager.ca/Certificate  (KRO input)
+  ├─ cert-manager.io/Certificate (KRO output → cert-manager)
+  └─ Secret (TLS)
+        │  api-syncagent syncs back
+        ▼
+Consumer workspace
+  └─ Secret cert-from-consumer (tls.crt, tls.key, ca.crt)
+```
+
+## Components
+
+### Platform Cluster
+
+Runs kcp and resource-broker. Hosts the `root:platform` workspace which
+exports the generic `identity.generic.platform-mesh.io/Certificate` API for
+consumers and the `acceptapis` API for providers.
+
+### Provider Workspace (`root:cert-manager`)
+
+The cert-manager provider's kcp workspace. api-syncagent fills in the
+`certificates` APIExport schema automatically. The `AcceptAPI` resource declares
+this provider can handle all `identity.generic.platform-mesh.io/certificates`.
+
+### Compute Cluster (`broker-cert-manager`)
+
+Runs cert-manager, kro, and api-syncagent. Our manifests under
+`examples/platform-mesh/cert-manager/` are applied here.
+
+### Consumer Workspace (`root:consumer`)
+
+Represents an end-user or tenant. Binds the `certificates` APIExport from the
+platform workspace and creates Certificate resources.
+
+## Provider Manifests
+
+The provider manifests live under `examples/platform-mesh/`:
+
+| File | Purpose |
+|---|---|
+| `cert-manager/issuer.yaml` | Self-signed `ClusterIssuer` on the compute cluster |
+| `cert-manager/rgd.yaml` | KRO `ResourceGraphDefinition` — translates `certmanager.ca/Certificate{fqdn}` → `cert-manager.io/Certificate` |
+| `cert-manager/publishedresource.yaml` | api-syncagent config — publishes local cert as `identity.generic.platform-mesh.io/Certificate` in kcp, syncs Secret back |
+| `root:providers:cert-manager/apiexport.yaml` | Minimal `APIExport` (api-syncagent fills in the schema) |
+| `root:providers:cert-manager/acceptapi.yaml` | Declares this provider handles `identity.generic.platform-mesh.io/certificates` |
+| `root:providers:cert-manager/bind-acceptapis.yaml` | Binds the `acceptapis` CRD from the platform workspace |
+
+## Prerequisites
+
+- `docker`
+- `kind`
+- `kubectl`
+- `helm`
+- `yq`
+- `go`
+
+<!--
+```bash ci
+source ./hack/lib.bash
+mkdir -p kubeconfigs/workspaces
+kcp::setup::plugins
+```
+-->
+
+## Running the Example
+
+### Setup
+
+<!--
+```bash ci
+if [[ -z "$CI" ]]; then
+    make docker-build-operator || die "Failed to build resource-broker-operator docker image"
+    make docker-build-kcp || die "Failed to build resource-broker-kcp docker image"
+fi
+```
+-->
+
+**Step 1 — Fix the vendor directory**
+
+Regenerates `vendor/modules.txt` if it has drifted from `go.mod`. No internet needed — modules are already in the Go cache.
+
+```bash ci
+go mod vendor
+```
+
+**Step 2 — Create the platform cluster**
+
+Hosts kcp and resource-broker.
+
+```bash ci
+kind::cluster platform kubeconfigs/platform.kubeconfig
+kind export kubeconfig --name broker-platform --kubeconfig kubeconfigs/platform.kubeconfig
+```
+
+**Step 3 — Install platform components**
+
+- **cert-manager** — kcp needs it to issue its own TLS certificates.
+- **etcd-druid** — manages the etcd cluster that kcp uses as its storage backend.
+- **kcp** — the multi-workspace API server.
+
+```bash ci
+helm::install::certmanager kubeconfigs/platform.kubeconfig
+helm::install::etcddruid kubeconfigs/platform.kubeconfig
+helm::install::kcp kubeconfigs/platform.kubeconfig
+```
+
+**Step 4 — Deploy resource-broker-operator**
+
+Manages the broker deployment lifecycle. Loads the pre-built image into kind (no registry needed) and applies its manifests.
+
+```bash ci
+make kind-load-operator KIND_CLUSTER=broker-platform
+make deploy-operator KUBECONFIG=kubeconfigs/platform.kubeconfig
+```
+
+**Step 5 — Bootstrap kcp and create the platform workspace**
+
+Applies the kcp bootstrap manifests (etcd cluster, front-proxy, root shard), waits for kcp to be ready, exports admin kubeconfigs, and creates `root:platform` — the workspace where the broker lives and all APIExports are published.
+
+```bash ci
+kubectl::kustomize kubeconfigs/platform.kubeconfig ./examples/kcp-certs/platform
+kcp::setup::kubeconfigs \
+  kubeconfigs/platform.kubeconfig \
+  kubeconfigs/kcp-admin.kubeconfig \
+  kubeconfigs/kcp-from-host.kubeconfig
+kcp::create_workspace \
+  kubeconfigs/kcp-admin.kubeconfig \
+  kubeconfigs/workspaces/platform.kubeconfig \
+  platform
+```
+
+**Step 6 — Install broker CRDs and create APIExports in the platform workspace**
+
+- Installs broker CRDs (`StagingWorkspace`, `Migration`, etc.) so the broker can persist its state inside kcp.
+- Creates the **`acceptapis` APIExport** — providers bind this to declare which APIs they can serve.
+- Creates the **`certificates` APIExport** for `identity.generic.platform-mesh.io/Certificate` — the generic API consumers bind to order certificates, independent of which provider backs it.
+
+```bash ci
+kubectl::apply kubeconfigs/workspaces/platform.kubeconfig \
+  ./config/broker/crd/broker.platform-mesh.io_migrationconfigurations.yaml \
+  ./config/broker/crd/broker.platform-mesh.io_migrations.yaml \
+  ./config/broker/crd/broker.platform-mesh.io_stagingworkspaces.yaml
+
+kcp::apiexport kubeconfigs/workspaces/platform.kubeconfig \
+  ./config/broker/crd/broker.platform-mesh.io_acceptapis.yaml \
+  secrets get,list,watch
+
+kcp::apiexport kubeconfigs/workspaces/platform.kubeconfig \
+  ./config/generic/crd/identity.generic.platform-mesh.io_certificates.yaml \
+  secrets '*' events '*' namespaces '*'
+```
+
+**Step 7 — Create the cert-manager compute cluster**
+
+The compute cluster is where the actual work happens — cert-manager signs certificates here and kro translates the generic `Certificate{fqdn}` into a real `cert-manager Certificate`. Completely separate from the platform cluster.
+
+```bash ci
+kind::cluster cert-manager kubeconfigs/cert-manager.kubeconfig
+kind export kubeconfig --name broker-cert-manager --kubeconfig kubeconfigs/cert-manager.kubeconfig
+helm::install::certmanager kubeconfigs/cert-manager.kubeconfig
+helm::install::kro kubeconfigs/cert-manager.kubeconfig
+```
+
+**Step 8 — Apply compute manifests (ClusterIssuer + KRO RGD)**
+
+- **`issuer.yaml`** — self-signed `ClusterIssuer` that cert-manager uses to sign certificates.
+- **`rgd.yaml`** — KRO `ResourceGraphDefinition` that registers the `certmanager.ca/Certificate` CRD and translates it into a `cert-manager.io/Certificate`.
+
+We wait for the RGD to become `Ready`, which confirms KRO has registered the CRD.
+
+```bash ci
+kubectl::kustomize kubeconfigs/cert-manager.kubeconfig ./examples/platform-mesh/cert-manager
+kubectl::wait kubeconfigs/cert-manager.kubeconfig rgd/certificates.certmanager.ca "" condition=Ready
+```
+
+**Step 9 — Create the cert-manager kcp workspace and a minimal APIExport**
+
+The provider workspace (`root:cert-manager`) is where the cert-manager provider lives inside kcp. The `certificates` APIExport is created with an empty spec — api-syncagent fills in the schema automatically when it starts.
+
+```bash ci
+kcp::create_workspace \
+  kubeconfigs/kcp-admin.kubeconfig \
+  kubeconfigs/workspaces/cert-manager.kubeconfig \
+  cert-manager
+
+kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig \
+  apply -f examples/platform-mesh/root:providers:cert-manager/apiexport.yaml
+```
+
+**Step 10 — Deploy api-syncagent on the compute cluster**
+
+api-syncagent bridges the compute cluster and kcp:
+1. Watches the provider kcp workspace for `identity.generic.platform-mesh.io/Certificate` objects routed by resource-broker.
+2. Creates corresponding `certmanager.ca/Certificate` objects on the compute cluster (picked up by KRO → cert-manager).
+3. Syncs the resulting TLS `Secret` back up to the consumer workspace.
+
+A service account is created in the provider workspace, a kubeconfig is generated for it, stored as a secret on the compute cluster, then api-syncagent is deployed via Helm pointing at that secret.
+
+```bash ci
+api_syncagent_token="$(kcp::serviceaccount::admin \
+  kubeconfigs/workspaces/cert-manager.kubeconfig api-syncagent default)"
+kubeconfig::create::token kubeconfigs/api-syncagent-cert-manager.kubeconfig \
+  "$(kubectl::kubeconfig::current_server_url kubeconfigs/workspaces/cert-manager.kubeconfig)" \
+  "$api_syncagent_token"
+kubectl::kubeconfig::secret kubeconfigs/cert-manager.kubeconfig \
+  kubeconfigs/api-syncagent-cert-manager.kubeconfig \
+  cert-manager default broker-platform-control-plane:32111
+
+helm::install::api_syncagent kubeconfigs/cert-manager.kubeconfig \
+  certificates cert-manager kubeconfig-cert-manager --set replicas=1
+```
+
+**Step 11 — Apply the PublishedResource**
+
+`publishedresource.yaml` tells api-syncagent:
+- **Local resource**: `certmanager.ca/Certificate` on the compute cluster.
+- **Projected as**: `identity.generic.platform-mesh.io/Certificate` in kcp.
+- **Related resource**: the TLS `Secret` — api-syncagent syncs this back to the consumer workspace.
+
+```bash ci
+kubectl --kubeconfig kubeconfigs/cert-manager.kubeconfig \
+  apply -f examples/platform-mesh/cert-manager/publishedresource.yaml
+```
+
+**Step 12 — Wire up the provider workspace**
+
+Wait for api-syncagent to update the `certificates` APIExport with the `certmanager.ca` schema projected as `identity.generic.platform-mesh.io`. Then:
+- **Bind `acceptapis`** from the platform workspace — gives the provider workspace the `AcceptAPI` CRD.
+- **Apply `acceptapi.yaml`** — declares this provider handles all `identity.generic.platform-mesh.io/certificates`. The `secret-name` annotation tells resource-broker which kubeconfig to use for routing.
+- **Bind the local `certificates` APIExport** back into the provider workspace so `identity.generic.platform-mesh.io/Certificate` is available locally for api-syncagent and resource-broker.
+
+```bash ci
+until kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig \
+  get apiexport certificates -o jsonpath='{.spec.resources}' 2>/dev/null \
+  | grep -q "identity"; do sleep 3; done
+
+kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig apply -f- <<EOF
+apiVersion: apis.kcp.io/v1alpha2
+kind: APIBinding
+metadata:
+  name: acceptapis
+spec:
+  reference:
+    export:
+      path: root:platform
+      name: acceptapis
+  permissionClaims:
+    - resource: secrets
+      group: ''
+      state: Accepted
+      verbs: ['get','list','watch']
+      selector:
+        matchAll: true
+EOF
+kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig \
+  wait --for=condition=Ready apibinding/acceptapis --timeout=60s
+
+kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig \
+  apply -f examples/platform-mesh/root:providers:cert-manager/acceptapi.yaml
+
+kcp::apibinding kubeconfigs/workspaces/cert-manager.kubeconfig "root:cert-manager" certificates \
+  secrets "" '*' events "" '*' namespaces "" '*'
+```
+
+**Step 13 — Create the VW kubeconfig for resource-broker and the consumer workspace**
+
+resource-broker needs a kubeconfig pointing at the provider's Virtual Workspace endpoint to write routed certificates into the provider workspace. Stored as a secret so the broker finds it via the `secret-name` annotation on the `AcceptAPI`.
+
+`root:consumer` is the workspace representing an end-user or tenant.
+
+```bash ci
+cluster_id=$(kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig \
+  get apiexportendpointslices/certificates \
+  -o jsonpath='{.metadata.annotations.kcp\.io/cluster}')
+endpoint_url="https://broker-platform-control-plane:32443/services/apiexport/$cluster_id/certificates/clusters/$cluster_id"
+sa_token="$(kcp::serviceaccount::admin \
+  kubeconfigs/workspaces/cert-manager.kubeconfig broker default)"
+kubeconfig::create::token \
+  kubeconfigs/workspaces/cert-manager.vw.kubeconfig "$endpoint_url" "$sa_token"
+kubectl::kubeconfig::secret kubeconfigs/workspaces/cert-manager.kubeconfig \
+  kubeconfigs/workspaces/cert-manager.vw.kubeconfig \
+  cert-manager default broker-platform-control-plane:32443
+
+kcp::create_workspace \
+  kubeconfigs/kcp-admin.kubeconfig \
+  kubeconfigs/workspaces/consumer.kubeconfig \
+  consumer
+```
+
+**Step 14 — Build and start resource-broker**
+
+resource-broker watches consumer workspaces for `identity.generic.platform-mesh.io/Certificate` objects, finds a matching provider via `AcceptAPI`, and routes the certificate to that provider's virtual workspace. The `watch-kind` is set to `identity.generic.platform-mesh.io` via `sed`.
+
+```bash ci
+make kind-load-kcp KIND_CLUSTER=broker-platform
+
+kubectl --kubeconfig kubeconfigs/platform.kubeconfig \
+  get secret operator-kubeconfig \
+  -o jsonpath='{.data.kubeconfig}' | base64 -d > kubeconfigs/operator.kubeconfig
+yq -i '(.clusters[] | select(.name=="default") | .cluster.server) += ":platform"' \
+  kubeconfigs/operator.kubeconfig
+
+kubectl create secret generic kcp-kubeconfig \
+  --namespace=resource-broker-system \
+  --dry-run=client -o yaml \
+  --from-file=kubeconfig=kubeconfigs/operator.kubeconfig \
+  | kubectl --kubeconfig kubeconfigs/platform.kubeconfig apply -f-
+
+cat examples/kcp-certs/platform/broker.yaml \
+  | sed 's|Certificate.v1alpha1.example.platform-mesh.io|Certificate.v1alpha1.identity.generic.platform-mesh.io|' \
+  | kubectl --kubeconfig kubeconfigs/platform.kubeconfig apply -f-
+
+kubectl::wait kubeconfigs/platform.kubeconfig \
+  broker/resource-broker resource-broker-system condition=Available
+```
+
+### Example
+
+**Step 15 — Consumer binds the Certificate API**
+
+The consumer workspace binds the `certificates` APIExport from the platform workspace, making `identity.generic.platform-mesh.io/Certificate` available to the tenant.
+
+```bash ci
+kcp::apibinding kubeconfigs/workspaces/consumer.kubeconfig "root:platform" certificates \
+  secrets "" '*' events "" '*' namespaces "" '*'
+```
+
+**Step 16 — Consumer orders a Certificate**
+
+The consumer creates a `Certificate` with just the `fqdn` they need. resource-broker routes it to the cert-manager provider, KRO translates it into a cert-manager Certificate, cert-manager signs it, and api-syncagent syncs the TLS Secret back.
+
+```bash ci
+kubectl --kubeconfig kubeconfigs/workspaces/consumer.kubeconfig apply -f- <<EOF
+apiVersion: identity.generic.platform-mesh.io/v1alpha1
+kind: Certificate
+metadata:
+  name: cert-from-consumer
+  namespace: default
+spec:
+  fqdn: my-app.platform-mesh.io
+EOF
+```
+
+**Step 17 — Verify**
+
+Wait for the TLS Secret to appear in the consumer workspace and confirm the certificate was issued for the right FQDN.
+
+<!--
+```bash ci
+kubectl::wait::cert::subject \
+  kubeconfigs/workspaces/consumer.kubeconfig \
+  "cert-from-consumer" \
+  "default" \
+  "my-app.platform-mesh.io"
+```
+-->
+
+```bash
+kubectl --kubeconfig kubeconfigs/workspaces/consumer.kubeconfig \
+  wait secret/cert-from-consumer --for=create --timeout=5m
+
+kubectl --kubeconfig kubeconfigs/workspaces/consumer.kubeconfig \
+  get secret cert-from-consumer \
+  -o jsonpath="{.data.tls\.crt}" | base64 -d | openssl x509 -noout -subject
+# Expected: subject=CN=my-app.platform-mesh.io
+```
+
+### Cleanup
+
+```bash noci
+for c in broker-platform broker-cert-manager; do
+  kind delete cluster --name "$c" 2>/dev/null || true
+done
+```

--- a/examples/cert-manager-msp/README.md
+++ b/examples/cert-manager-msp/README.md
@@ -82,280 +82,111 @@ The provider manifests live under `examples/platform-mesh/`:
 - `yq`
 - `go`
 
-<!--
-```bash ci
-source ./hack/lib.bash
-mkdir -p kubeconfigs/workspaces
-kcp::setup::plugins
-```
--->
-
 ## Running the Example
 
 ### Setup
 
-<!--
-```bash ci
-if [[ -z "$CI" ]]; then
-    make docker-build-operator || die "Failed to build resource-broker-operator docker image"
-    make docker-build-kcp || die "Failed to build resource-broker-kcp docker image"
-fi
-```
--->
+This msp example expects basic knowledge from the kcp-certs example.
 
-**Step 1 — Fix the vendor directory**
+**Step 1 — Bring up the platform and the empty compute cluster**
 
-Regenerates `vendor/modules.txt` if it has drifted from `go.mod`. No internet needed — modules are already in the Go cache.
+Creates the `broker-platform` and `broker-cert-manager` kind clusters,
+installs cert-manager / etcd-druid / kcp / kro, deploys
+resource-broker-operator, bootstraps kcp, and creates the platform workspace
+with the `acceptapis` and `certificates` APIExports.
 
 ```bash ci
-go mod vendor
+./examples/cert-manager-msp/run.bash setup-platform
 ```
 
-**Step 2 — Create the platform cluster**
+**Step 2 — Apply compute manifests (ClusterIssuer + KRO RGD)**
 
-Hosts kcp and resource-broker.
-
-```bash ci
-kind::cluster platform kubeconfigs/platform.kubeconfig
-kind export kubeconfig --name broker-platform --kubeconfig kubeconfigs/platform.kubeconfig
-```
-
-**Step 3 — Install platform components**
-
-- **cert-manager** — kcp needs it to issue its own TLS certificates.
-- **etcd-druid** — manages the etcd cluster that kcp uses as its storage backend.
-- **kcp** — the multi-workspace API server.
-
-```bash ci
-helm::install::certmanager kubeconfigs/platform.kubeconfig
-helm::install::etcddruid kubeconfigs/platform.kubeconfig
-helm::install::kcp kubeconfigs/platform.kubeconfig
-```
-
-**Step 4 — Deploy resource-broker-operator**
-
-Manages the broker deployment lifecycle. Loads the pre-built image into kind (no registry needed) and applies its manifests.
-
-```bash ci
-make kind-load-operator KIND_CLUSTER=broker-platform
-make deploy-operator KUBECONFIG=kubeconfigs/platform.kubeconfig
-```
-
-**Step 5 — Bootstrap kcp and create the platform workspace**
-
-Applies the kcp bootstrap manifests (etcd cluster, front-proxy, root shard), waits for kcp to be ready, exports admin kubeconfigs, and creates `root:platform` — the workspace where the broker lives and all APIExports are published.
-
-```bash ci
-kubectl::kustomize kubeconfigs/platform.kubeconfig ./examples/kcp-certs/platform
-kcp::setup::kubeconfigs \
-  kubeconfigs/platform.kubeconfig \
-  kubeconfigs/kcp-admin.kubeconfig \
-  kubeconfigs/kcp-from-host.kubeconfig
-kcp::create_workspace \
-  kubeconfigs/kcp-admin.kubeconfig \
-  kubeconfigs/workspaces/platform.kubeconfig \
-  platform
-```
-
-**Step 6 — Install broker CRDs and create APIExports in the platform workspace**
-
-- Installs broker CRDs (`StagingWorkspace`, `Migration`, etc.) so the broker can persist its state inside kcp.
-- Creates the **`acceptapis` APIExport** — providers bind this to declare which APIs they can serve.
-- Creates the **`certificates` APIExport** for `identity.generic.platform-mesh.io/Certificate` — the generic API consumers bind to order certificates, independent of which provider backs it.
-
-```bash ci
-kubectl::apply kubeconfigs/workspaces/platform.kubeconfig \
-  ./config/broker/crd/broker.platform-mesh.io_migrationconfigurations.yaml \
-  ./config/broker/crd/broker.platform-mesh.io_migrations.yaml \
-  ./config/broker/crd/broker.platform-mesh.io_stagingworkspaces.yaml
-
-kcp::apiexport kubeconfigs/workspaces/platform.kubeconfig \
-  ./config/broker/crd/broker.platform-mesh.io_acceptapis.yaml \
-  secrets get,list,watch
-
-kcp::apiexport kubeconfigs/workspaces/platform.kubeconfig \
-  ./config/generic/crd/identity.generic.platform-mesh.io_certificates.yaml \
-  secrets '*' events '*' namespaces '*'
-```
-
-**Step 7 — Create the cert-manager compute cluster**
-
-The compute cluster is where the actual work happens — cert-manager signs certificates here and kro translates the generic `Certificate{fqdn}` into a real `cert-manager Certificate`. Completely separate from the platform cluster.
-
-```bash ci
-kind::cluster cert-manager kubeconfigs/cert-manager.kubeconfig
-kind export kubeconfig --name broker-cert-manager --kubeconfig kubeconfigs/cert-manager.kubeconfig
-helm::install::certmanager kubeconfigs/cert-manager.kubeconfig
-helm::install::kro kubeconfigs/cert-manager.kubeconfig
-```
-
-**Step 8 — Apply compute manifests (ClusterIssuer + KRO RGD)**
-
-- **`issuer.yaml`** — self-signed `ClusterIssuer` that cert-manager uses to sign certificates.
-- **`rgd.yaml`** — KRO `ResourceGraphDefinition` that registers the `certmanager.ca/Certificate` CRD and translates it into a `cert-manager.io/Certificate`.
+- **`issuer.yaml`** — self-signed `ClusterIssuer` that cert-manager uses to
+  sign certificates.
+- **`rgd.yaml`** — KRO `ResourceGraphDefinition` that registers the
+  `certmanager.ca/Certificate` CRD and translates it into a
+  `cert-manager.io/Certificate`.
 
 We wait for the RGD to become `Ready`, which confirms KRO has registered the CRD.
 
 ```bash ci
-kubectl::kustomize kubeconfigs/cert-manager.kubeconfig ./examples/platform-mesh/cert-manager
-kubectl::wait kubeconfigs/cert-manager.kubeconfig rgd/certificates.certmanager.ca "" condition=Ready
-```
-
-**Step 9 — Create the cert-manager kcp workspace and a minimal APIExport**
-
-The provider workspace (`root:cert-manager`) is where the cert-manager provider lives inside kcp. The `certificates` APIExport is created with an empty spec — api-syncagent fills in the schema automatically when it starts.
-
-```bash ci
-kcp::create_workspace \
-  kubeconfigs/kcp-admin.kubeconfig \
-  kubeconfigs/workspaces/cert-manager.kubeconfig \
-  cert-manager
-
-kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig \
-  apply -f examples/platform-mesh/root:providers:cert-manager/apiexport.yaml
-```
-
-**Step 10 — Deploy api-syncagent on the compute cluster**
-
-api-syncagent bridges the compute cluster and kcp:
-1. Watches the provider kcp workspace for `identity.generic.platform-mesh.io/Certificate` objects routed by resource-broker.
-2. Creates corresponding `certmanager.ca/Certificate` objects on the compute cluster (picked up by KRO → cert-manager).
-3. Syncs the resulting TLS `Secret` back up to the consumer workspace.
-
-A service account is created in the provider workspace, a kubeconfig is generated for it, stored as a secret on the compute cluster, then api-syncagent is deployed via Helm pointing at that secret.
-
-```bash ci
-api_syncagent_token="$(kcp::serviceaccount::admin \
-  kubeconfigs/workspaces/cert-manager.kubeconfig api-syncagent default)"
-kubeconfig::create::token kubeconfigs/api-syncagent-cert-manager.kubeconfig \
-  "$(kubectl::kubeconfig::current_server_url kubeconfigs/workspaces/cert-manager.kubeconfig)" \
-  "$api_syncagent_token"
-kubectl::kubeconfig::secret kubeconfigs/cert-manager.kubeconfig \
-  kubeconfigs/api-syncagent-cert-manager.kubeconfig \
-  cert-manager default broker-platform-control-plane:32111
-
-helm::install::api_syncagent kubeconfigs/cert-manager.kubeconfig \
-  certificates cert-manager kubeconfig-cert-manager --set replicas=1
-```
-
-**Step 11 — Apply the PublishedResource**
-
-`publishedresource.yaml` tells api-syncagent:
-- **Local resource**: `certmanager.ca/Certificate` on the compute cluster.
-- **Projected as**: `identity.generic.platform-mesh.io/Certificate` in kcp.
-- **Related resource**: the TLS `Secret` — api-syncagent syncs this back to the consumer workspace.
-
-```bash ci
 kubectl --kubeconfig kubeconfigs/cert-manager.kubeconfig \
-  apply -f examples/platform-mesh/cert-manager/publishedresource.yaml
+  apply -k ./examples/platform-mesh/cert-manager
+kubectl --kubeconfig kubeconfigs/cert-manager.kubeconfig \
+  wait --for=condition=Ready rgd/certificates.certmanager.ca --timeout=120s
 ```
 
-**Step 12 — Wire up the provider workspace**
+**Step 3 — Wire up the cert-manager provider**
 
-Wait for api-syncagent to update the `certificates` APIExport with the `certmanager.ca` schema projected as `identity.generic.platform-mesh.io`. Then:
-- **Bind `acceptapis`** from the platform workspace — gives the provider workspace the `AcceptAPI` CRD.
-- **Apply `acceptapi.yaml`** — declares this provider handles all `identity.generic.platform-mesh.io/certificates`. The `secret-name` annotation tells resource-broker which kubeconfig to use for routing.
-- **Bind the local `certificates` APIExport** back into the provider workspace so `identity.generic.platform-mesh.io/Certificate` is available locally for api-syncagent and resource-broker.
+Creates the `root:cert-manager` workspace and its `certificates` APIExport,
+deploys api-syncagent on the compute cluster, applies the
+`PublishedResource`, binds and applies the `AcceptAPI`, creates the VW
+kubeconfig that resource-broker uses to write into the provider workspace,
+and creates the consumer workspace.
 
 ```bash ci
-until kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig \
-  get apiexport certificates -o jsonpath='{.spec.resources}' 2>/dev/null \
-  | grep -q "identity"; do sleep 3; done
-
-kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig apply -f- <<EOF
-apiVersion: apis.kcp.io/v1alpha2
-kind: APIBinding
-metadata:
-  name: acceptapis
-spec:
-  reference:
-    export:
-      path: root:platform
-      name: acceptapis
-  permissionClaims:
-    - resource: secrets
-      group: ''
-      state: Accepted
-      verbs: ['get','list','watch']
-      selector:
-        matchAll: true
-EOF
-kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig \
-  wait --for=condition=Ready apibinding/acceptapis --timeout=60s
-
-kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig \
-  apply -f examples/platform-mesh/root:providers:cert-manager/acceptapi.yaml
-
-kcp::apibinding kubeconfigs/workspaces/cert-manager.kubeconfig "root:cert-manager" certificates \
-  secrets "" '*' events "" '*' namespaces "" '*'
+./examples/cert-manager-msp/run.bash setup-provider
 ```
 
-**Step 13 — Create the VW kubeconfig for resource-broker and the consumer workspace**
+**Step 4 — Start resource-broker**
 
-resource-broker needs a kubeconfig pointing at the provider's Virtual Workspace endpoint to write routed certificates into the provider workspace. Stored as a secret so the broker finds it via the `secret-name` annotation on the `AcceptAPI`.
-
-`root:consumer` is the workspace representing an end-user or tenant.
-
-```bash ci
-cluster_id=$(kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig \
-  get apiexportendpointslices/certificates \
-  -o jsonpath='{.metadata.annotations.kcp\.io/cluster}')
-endpoint_url="https://broker-platform-control-plane:32443/services/apiexport/$cluster_id/certificates/clusters/$cluster_id"
-sa_token="$(kcp::serviceaccount::admin \
-  kubeconfigs/workspaces/cert-manager.kubeconfig broker default)"
-kubeconfig::create::token \
-  kubeconfigs/workspaces/cert-manager.vw.kubeconfig "$endpoint_url" "$sa_token"
-kubectl::kubeconfig::secret kubeconfigs/workspaces/cert-manager.kubeconfig \
-  kubeconfigs/workspaces/cert-manager.vw.kubeconfig \
-  cert-manager default broker-platform-control-plane:32443
-
-kcp::create_workspace \
-  kubeconfigs/kcp-admin.kubeconfig \
-  kubeconfigs/workspaces/consumer.kubeconfig \
-  consumer
-```
-
-**Step 14 — Build and start resource-broker**
-
-resource-broker watches consumer workspaces for `identity.generic.platform-mesh.io/Certificate` objects, finds a matching provider via `AcceptAPI`, and routes the certificate to that provider's virtual workspace. The `watch-kind` is set to `identity.generic.platform-mesh.io` via `sed`.
+Builds and loads the resource-broker image, mounts the operator kubeconfig
+into the broker, and applies the `Broker` resource configured to watch
+`identity.generic.platform-mesh.io/Certificate`.
 
 ```bash ci
-make kind-load-kcp KIND_CLUSTER=broker-platform
-
-kubectl --kubeconfig kubeconfigs/platform.kubeconfig \
-  get secret operator-kubeconfig \
-  -o jsonpath='{.data.kubeconfig}' | base64 -d > kubeconfigs/operator.kubeconfig
-yq -i '(.clusters[] | select(.name=="default") | .cluster.server) += ":platform"' \
-  kubeconfigs/operator.kubeconfig
-
-kubectl create secret generic kcp-kubeconfig \
-  --namespace=resource-broker-system \
-  --dry-run=client -o yaml \
-  --from-file=kubeconfig=kubeconfigs/operator.kubeconfig \
-  | kubectl --kubeconfig kubeconfigs/platform.kubeconfig apply -f-
-
-cat examples/kcp-certs/platform/broker.yaml \
-  | sed 's|Certificate.v1alpha1.example.platform-mesh.io|Certificate.v1alpha1.identity.generic.platform-mesh.io|' \
-  | kubectl --kubeconfig kubeconfigs/platform.kubeconfig apply -f-
-
-kubectl::wait kubeconfigs/platform.kubeconfig \
-  broker/resource-broker resource-broker-system condition=Available
+./examples/cert-manager-msp/run.bash start-broker
 ```
 
 ### Example
 
-**Step 15 — Consumer binds the Certificate API**
+**Step 5 — Consumer binds the Certificate API**
 
-The consumer workspace binds the `certificates` APIExport from the platform workspace, making `identity.generic.platform-mesh.io/Certificate` available to the tenant.
+The consumer workspace binds the `certificates` APIExport from the platform
+workspace, making `identity.generic.platform-mesh.io/Certificate` available
+to the tenant.
 
 ```bash ci
-kcp::apibinding kubeconfigs/workspaces/consumer.kubeconfig "root:platform" certificates \
-  secrets "" '*' events "" '*' namespaces "" '*'
+kubectl --kubeconfig kubeconfigs/workspaces/consumer.kubeconfig apply -f- <<EOF
+apiVersion: apis.kcp.io/v1alpha2
+kind: APIBinding
+metadata:
+  name: certificates
+spec:
+  reference:
+    export:
+      path: root:platform
+      name: certificates
+  permissionClaims:
+    - resource: secrets
+      group: ''
+      state: Accepted
+      verbs: ['*']
+      selector:
+        matchAll: true
+    - resource: events
+      group: ''
+      state: Accepted
+      verbs: ['*']
+      selector:
+        matchAll: true
+    - resource: namespaces
+      group: ''
+      state: Accepted
+      verbs: ['*']
+      selector:
+        matchAll: true
+EOF
+kubectl --kubeconfig kubeconfigs/workspaces/consumer.kubeconfig \
+  wait --for=condition=Ready apibinding/certificates --timeout=60s
 ```
 
-**Step 16 — Consumer orders a Certificate**
+**Step 6 — Consumer orders a Certificate**
 
-The consumer creates a `Certificate` with just the `fqdn` they need. resource-broker routes it to the cert-manager provider, KRO translates it into a cert-manager Certificate, cert-manager signs it, and api-syncagent syncs the TLS Secret back.
+The consumer creates a `Certificate` with just the `fqdn` they need.
+resource-broker routes it to the cert-manager provider, KRO translates it
+into a cert-manager Certificate, cert-manager signs it, and api-syncagent
+syncs the TLS Secret back.
 
 ```bash ci
 kubectl --kubeconfig kubeconfigs/workspaces/consumer.kubeconfig apply -f- <<EOF
@@ -369,21 +200,12 @@ spec:
 EOF
 ```
 
-**Step 17 — Verify**
+**Step 7 — Verify**
 
-Wait for the TLS Secret to appear in the consumer workspace and confirm the certificate was issued for the right FQDN.
+Wait for the TLS Secret to appear in the consumer workspace and confirm the
+certificate was issued for the right FQDN.
 
-<!--
 ```bash ci
-kubectl::wait::cert::subject \
-  kubeconfigs/workspaces/consumer.kubeconfig \
-  "cert-from-consumer" \
-  "default" \
-  "my-app.platform-mesh.io"
-```
--->
-
-```bash
 kubectl --kubeconfig kubeconfigs/workspaces/consumer.kubeconfig \
   wait secret/cert-from-consumer --for=create --timeout=5m
 
@@ -395,8 +217,16 @@ kubectl --kubeconfig kubeconfigs/workspaces/consumer.kubeconfig \
 
 ### Cleanup
 
+Removes the consumer's Certificate and APIBinding so step 5 onwards can be
+re-run against the same platform / provider setup.
+
 ```bash noci
-for c in broker-platform broker-cert-manager; do
-  kind delete cluster --name "$c" 2>/dev/null || true
-done
+./examples/cert-manager-msp/run.bash cleanup
+```
+
+To tear down the whole environment, delete the kind clusters:
+
+```bash noci
+kind delete cluster --name broker-platform
+kind delete cluster --name broker-cert-manager
 ```

--- a/examples/cert-manager-msp/run.bash
+++ b/examples/cert-manager-msp/run.bash
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+
+# cd into repo root
+example_dir="$(realpath "$(dirname "$0")")"
+cd "$example_dir/../.."
+source "./hack/lib.bash"
+
+if [[ -n "$CI" ]]; then
+    kcp::setup::plugins
+fi
+
+kubeconfigs="$PWD/kubeconfigs"
+log "Using directory for kubeconfigs: $kubeconfigs"
+
+workspace_kubeconfigs="$kubeconfigs/workspaces"
+mkdir -p "$workspace_kubeconfigs"
+
+kind_platform="$kubeconfigs/platform.kubeconfig"
+ws_platform="$workspace_kubeconfigs/platform.kubeconfig"
+
+kind_certmanager="$kubeconfigs/cert-manager.kubeconfig"
+ws_certmanager="$workspace_kubeconfigs/cert-manager.kubeconfig"
+vw_certmanager="$workspace_kubeconfigs/cert-manager.vw.kubeconfig"
+
+ws_consumer="$workspace_kubeconfigs/consumer.kubeconfig"
+
+_setup_platform() {
+    log "Setting up platform cluster"
+    kind::cluster platform "$kind_platform"
+    helm::install::certmanager "$kind_platform"
+    helm::install::etcddruid "$kind_platform"
+    helm::install::kcp "$kind_platform"
+
+    log "Deploy resource-broker-operator"
+    if [[ -z "$CI" ]]; then
+        make docker-build-operator || die "Failed to build resource-broker-operator docker image"
+    fi
+    make kind-load-operator KIND_CLUSTER=broker-platform \
+        || die "Failed to load resource-broker-operator into kind cluster"
+    make deploy-operator KUBECONFIG="$kind_platform" || die "Failed to deploy resource-broker-operator"
+
+    log "Setting up kcp"
+    kubectl::kustomize "$kind_platform" "./examples/kcp-certs/platform"
+    kcp::setup::kubeconfigs \
+        "$kind_platform" \
+        "$kubeconfigs/kcp-admin.kubeconfig" \
+        "$kubeconfigs/kcp-from-host.kubeconfig"
+
+    log "Setting up platform kcp workspace"
+    kcp::create_workspace "$kubeconfigs/kcp-admin.kubeconfig" "$ws_platform" "platform"
+
+    log "Installing broker CRDs into platform workspace"
+    kubectl::apply \
+        "$ws_platform" \
+        ./config/broker/crd/broker.platform-mesh.io_migrationconfigurations.yaml \
+        ./config/broker/crd/broker.platform-mesh.io_migrations.yaml \
+        ./config/broker/crd/broker.platform-mesh.io_stagingworkspaces.yaml
+
+    log "Setting up AcceptAPI APIExport for providers"
+    kcp::apiexport "$ws_platform" ./config/broker/crd/broker.platform-mesh.io_acceptapis.yaml \
+        secrets get,list,watch
+
+    log "Setting up Certificate APIExport for consumers"
+    kcp::apiexport "$ws_platform" \
+        ./config/generic/crd/identity.generic.platform-mesh.io_certificates.yaml \
+        secrets '*' \
+        events '*' \
+        namespaces '*'
+
+    log "Setting up cert-manager compute cluster"
+    kind::cluster cert-manager "$kind_certmanager"
+    helm::install::certmanager "$kind_certmanager"
+    helm::install::kro "$kind_certmanager"
+}
+
+_setup_provider() {
+    log "Setting up cert-manager kcp workspace and APIExport"
+    kcp::create_workspace "$kubeconfigs/kcp-admin.kubeconfig" "$ws_certmanager" "cert-manager"
+    kubectl --kubeconfig "$ws_certmanager" \
+        apply -f "$example_dir/../platform-mesh/root:providers:cert-manager/apiexport.yaml"
+
+    log "Deploying api-syncagent on the compute cluster"
+    local api_syncagent_token
+    api_syncagent_token="$(kcp::serviceaccount::admin "$ws_certmanager" api-syncagent default)"
+    local api_syncagent_kubeconfig="$kubeconfigs/api-syncagent-cert-manager.kubeconfig"
+    kubeconfig::create::token "$api_syncagent_kubeconfig" \
+        "$(kubectl::kubeconfig::current_server_url "$ws_certmanager")" \
+        "$api_syncagent_token"
+    kubectl::kubeconfig::secret "$kind_certmanager" "$api_syncagent_kubeconfig" \
+        cert-manager default broker-platform-control-plane:32111
+
+    helm::install::api_syncagent "$kind_certmanager" \
+        certificates cert-manager kubeconfig-cert-manager --set replicas=1
+
+    log "Applying PublishedResource"
+    kubectl --kubeconfig "$kind_certmanager" \
+        apply -f "$example_dir/../platform-mesh/cert-manager/publishedresource.yaml"
+
+    log "Wiring up the cert-manager provider workspace"
+    until kubectl --kubeconfig "$ws_certmanager" \
+        get apiexport certificates -o jsonpath='{.spec.resources}' 2>/dev/null \
+        | grep -q "identity"; do sleep 3; done
+
+    kubectl --kubeconfig "$ws_certmanager" apply -f- <<EOF
+apiVersion: apis.kcp.io/v1alpha2
+kind: APIBinding
+metadata:
+  name: acceptapis
+spec:
+  reference:
+    export:
+      path: root:platform
+      name: acceptapis
+  permissionClaims:
+    - resource: secrets
+      group: ''
+      state: Accepted
+      verbs: ['get','list','watch']
+      selector:
+        matchAll: true
+EOF
+    kubectl --kubeconfig "$ws_certmanager" \
+        wait --for=condition=Ready apibinding/acceptapis --timeout=60s
+
+    kubectl --kubeconfig "$ws_certmanager" \
+        apply -f "$example_dir/../platform-mesh/root:providers:cert-manager/acceptapi.yaml"
+
+    kcp::apibinding "$ws_certmanager" "root:cert-manager" certificates \
+        secrets "" '*' \
+        events "" '*' \
+        namespaces "" '*'
+
+    log "Creating VW kubeconfig for resource-broker"
+    local cluster_id
+    cluster_id="$(kubectl --kubeconfig "$ws_certmanager" \
+        get apiexportendpointslices/certificates \
+        -o jsonpath='{.metadata.annotations.kcp\.io/cluster}')"
+    local endpoint_url="https://broker-platform-control-plane:32443/services/apiexport/$cluster_id/certificates/clusters/$cluster_id"
+    local sa_token
+    sa_token="$(kcp::serviceaccount::admin "$ws_certmanager" broker default)"
+    kubeconfig::create::token "$vw_certmanager" "$endpoint_url" "$sa_token"
+    kubectl::kubeconfig::secret "$ws_certmanager" "$vw_certmanager" \
+        cert-manager default broker-platform-control-plane:32443
+
+    log "Setting up consumer kcp workspace"
+    kcp::create_workspace "$kubeconfigs/kcp-admin.kubeconfig" "$ws_consumer" "consumer"
+}
+
+_start_broker() {
+    log "Starting broker"
+
+    if [[ -z "$CI" ]]; then
+        make docker-build-kcp || die "Failed to build resource-broker-kcp docker image"
+    fi
+    make kind-load-kcp KIND_CLUSTER=broker-platform \
+        || die "Failed to load resource-broker-kcp image into kind cluster"
+
+    KUBECONFIG="$kind_platform" \
+        kubectl get secret operator-kubeconfig -o jsonpath='{.data.kubeconfig}' \
+            | base64 -d \
+            > "$kubeconfigs/operator.kubeconfig" \
+            || die "Failed to get operator kubeconfig from kind cluster"
+    yq -i '(.clusters[] | select(.name=="default") | .cluster.server) += ":platform"' \
+        "$kubeconfigs/operator.kubeconfig" \
+        || die "Failed to modify operator kubeconfig server URL"
+
+    kubectl create secret generic kcp-kubeconfig \
+        --namespace=resource-broker-system --dry-run=client -o yaml \
+        --from-file=kubeconfig="$kubeconfigs/operator.kubeconfig" \
+        | kubectl::apply "$kind_platform" "-"
+
+    sed 's|Certificate.v1alpha1.example.platform-mesh.io|Certificate.v1alpha1.identity.generic.platform-mesh.io|' \
+        examples/kcp-certs/platform/broker.yaml \
+        | kubectl --kubeconfig "$kind_platform" apply -f-
+
+    kubectl::wait "$kind_platform" broker/resource-broker resource-broker-system condition=Available
+}
+
+_cleanup() {
+    log "Removing consumer Certificate"
+    kubectl --kubeconfig "$ws_consumer" delete --ignore-not-found \
+        -n default certificates.identity.generic.platform-mesh.io/cert-from-consumer
+
+    log "Removing consumer APIBinding"
+    kubectl --kubeconfig "$ws_consumer" delete --ignore-not-found \
+        apibinding/certificates
+}
+
+case "$1" in
+    (setup-platform) _setup_platform ;;
+    (setup-provider) _setup_provider ;;
+    (start-broker) _start_broker ;;
+    (cleanup) _cleanup ;;
+    (*) die "Unknown command: $1" ;;
+esac

--- a/examples/certs/platform/broker.yaml
+++ b/examples/certs/platform/broker.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: resource-broker-system
 spec:
   image:
-    repository: resource-broker
+    repository: localhost/resource-broker
     tag: dev
   extraArgs:
     - "-kubeconfig=/kubeconfigs/platform/kubeconfig"

--- a/examples/kcp-certs/platform/broker.yaml
+++ b/examples/kcp-certs/platform/broker.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: resource-broker-system
 spec:
   image:
-    repository: resource-broker-kcp
+    repository: localhost/resource-broker-kcp
     tag: dev
   extraArgs:
     - "-kubeconfig=/kubeconfig/kubeconfig"

--- a/examples/platform-mesh/cert-manager/issuer.yaml
+++ b/examples/platform-mesh/cert-manager/issuer.yaml
@@ -1,0 +1,6 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-cert-manager-issuer
+spec:
+  selfSigned: {}

--- a/examples/platform-mesh/cert-manager/kustomization.yaml
+++ b/examples/platform-mesh/cert-manager/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - issuer.yaml
+  - rgd.yaml

--- a/examples/platform-mesh/cert-manager/publishedresource.yaml
+++ b/examples/platform-mesh/cert-manager/publishedresource.yaml
@@ -1,0 +1,53 @@
+apiVersion: syncagent.kcp.io/v1alpha1
+kind: PublishedResource
+metadata:
+  name: certificates.certmanager.ca
+  labels:
+    ca: cert-manager
+spec:
+  resource:
+    kind: Certificate
+    apiGroup: certmanager.ca
+    versions: [v1alpha1]
+  projection:
+    group: identity.generic.platform-mesh.io
+  naming:
+    namespace: cert-manager-{{.ClusterName}}
+  related:
+    - identifier: certificate
+      origin: service
+      kind: Secret
+      object:
+        reference:
+          path: status.relatedResources.secret.name
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: api-syncagent-cert-manager:certificates
+rules:
+  - apiGroups:
+      - certmanager.ca
+    resources:
+      - certificates
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: api-syncagent-cert-manager:certificates
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: api-syncagent-cert-manager:certificates
+subjects:
+  - kind: ServiceAccount
+    name: api-syncagent-cert-manager
+    namespace: default

--- a/examples/platform-mesh/cert-manager/rgd.yaml
+++ b/examples/platform-mesh/cert-manager/rgd.yaml
@@ -1,0 +1,56 @@
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: certificates.certmanager.ca
+spec:
+
+  schema:
+    group: certmanager.ca
+    apiVersion: v1alpha1
+    kind: Certificate
+    spec:
+      fqdn: string
+    status:
+      status: ${certificate.status.conditions.exists(c, c.type == "Ready" && c.status == "True") ? "Available":"Unavailable"}
+      conditions: ${certificate.status.conditions}
+      relatedResources:
+        secret:
+          gvk:
+            group: ${secret.apiVersion == "v1" ? "core":secret.apiVersion.split("/")[0]}
+            version: ${secret.?apiVersion}
+            kind: ${secret.?kind}
+          name: ${secret.metadata.name}
+          namespace: ${certificate.metadata.?annotations["remote-object-namespace"]}
+
+  resources:
+
+    - id: certificate
+      template:
+        apiVersion: cert-manager.io/v1
+        kind: Certificate
+        metadata:
+          annotations:
+            remote-object-name: ${schema.metadata.?annotations["syncagent.kcp.io/remote-object-name"]}
+            remote-object-namespace: ${schema.metadata.?annotations["syncagent.kcp.io/remote-object-namespace"]}
+          name: ${schema.metadata.name}
+          namespace: ${schema.metadata.namespace}
+        spec:
+          commonName: ${schema.spec.fqdn}
+          secretName: ${schema.metadata.?annotations["syncagent.kcp.io/remote-object-name"]}
+          privateKey:
+            algorithm: ECDSA
+            size: 256
+          issuerRef:
+            name: selfsigned-cert-manager-issuer
+            kind: ClusterIssuer
+            group: cert-manager.io
+
+    - id: secret
+      externalRef:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: ${certificate.metadata.?annotations["remote-object-name"]}
+          namespace: ${certificate.metadata.namespace}
+      readyWhen:
+        - ${secret.metadata.name != ""}

--- a/examples/platform-mesh/root:providers:cert-manager/acceptapi.yaml
+++ b/examples/platform-mesh/root:providers:cert-manager/acceptapi.yaml
@@ -1,0 +1,12 @@
+apiVersion: broker.platform-mesh.io/v1alpha1
+kind: AcceptAPI
+metadata:
+  annotations:
+    broker.platform-mesh.io/kcp-apiexport-name: certificates
+    broker.platform-mesh.io/secret-name: kubeconfig-cert-manager
+  name: v1alpha1.certificates.identity.generic.platform-mesh.io
+spec:
+  gvr:
+    group: identity.generic.platform-mesh.io
+    version: v1alpha1
+    resource: certificates

--- a/examples/platform-mesh/root:providers:cert-manager/apiexport.yaml
+++ b/examples/platform-mesh/root:providers:cert-manager/apiexport.yaml
@@ -1,0 +1,5 @@
+apiVersion: apis.kcp.io/v1alpha2
+kind: APIExport
+metadata:
+  name: certificates
+spec: {}

--- a/examples/platform-mesh/root:providers:cert-manager/bind-acceptapis.yaml
+++ b/examples/platform-mesh/root:providers:cert-manager/bind-acceptapis.yaml
@@ -1,0 +1,25 @@
+apiVersion: apis.kcp.io/v1alpha2
+kind: APIBinding
+metadata:
+  name: acceptapis
+spec:
+  reference:
+    export:
+      path: root:providers:resource-broker
+      name: acceptapis
+  permissionClaims:
+    - resource: secrets
+      state: Accepted
+      verbs: ["*"]
+      selector:
+        matchAll: true
+    - resource: events
+      state: Accepted
+      verbs: ["*"]
+      selector:
+        matchAll: true
+    - resource: namespaces
+      state: Accepted
+      verbs: ["*"]
+      selector:
+        matchAll: true

--- a/examples/platform-mesh/root:providers:cert-manager/kustomization.yaml
+++ b/examples/platform-mesh/root:providers:cert-manager/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - apiexport.yaml
+  - bind-acceptapis.yaml
+  - acceptapi.yaml

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
+	github.com/gomarkdown/markdown v0.0.0-20250810172220-2e2c11897d1a // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -45,6 +46,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/ntnn/mdextract v0.4.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/gomarkdown/markdown v0.0.0-20250810172220-2e2c11897d1a h1:l7A0loSszR5zHd/qK53ZIHMO8b3bBSmENnQ6eKnUT0A=
+github.com/gomarkdown/markdown v0.0.0-20250810172220-2e2c11897d1a/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/cel-go v0.27.0 h1:e7ih85+4qVrBuqQWTW4FKSqZYokVuc3HnhH5keboFTo=
@@ -93,6 +95,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/ntnn/mdextract v0.4.1 h1:W3V6NGriIBazjezKl9uSZjQCa5gX1UlNoMKoRbAQNN0=
+github.com/ntnn/mdextract v0.4.1/go.mod h1:K/lD8P/Rgzeek5VMbPNnKHfotJ0PuBaal1aC2niLgr4=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=


### PR DESCRIPTION
## Description

Adds the cert-manager Managed Service Provider as a concrete provider for the
resource-broker generic Certificate API, replacing the previously scaffolded
custom MCR operator approach.

## What changed

Added 8 YAML files under `examples/platform-mesh/cert-manager/` and
`examples/platform-mesh/root:providers:cert-manager/`. No existing files modified,
no operator code written.

**Compute cluster side (`cert-manager/`)**
- `issuer.yaml` — self-signed ClusterIssuer for cert-manager
- `rgd.yaml` — KRO ResourceGraphDefinition translating generic Certificate{fqdn}
  into a cert-manager Certificate
- `publishedresource.yaml` — api-syncagent config: publishes certmanager.ca/Certificate
  to kcp as identity.generic.platform-mesh.io/Certificate and syncs TLS Secret back
- `kustomization.yaml`

**Provider kcp workspace side (`root:providers:cert-manager/`)**
- `apiexport.yaml` — minimal APIExport managed by api-syncagent
- `acceptapi.yaml` — declares this provider handles identity.generic.platform-mesh.io/certificates
- `bind-acceptapis.yaml` — binds AcceptAPI CRD from platform workspace
- `kustomization.yaml`

## How it works

Consumer creates `identity.generic.platform-mesh.io/Certificate{fqdn}`
→ resource-broker routes it to the cert-manager provider via AcceptAPI
→ api-syncagent syncs it to the compute cluster as `certmanager.ca/Certificate`
→ KRO translates it to a `cert-manager.io/Certificate`
→ cert-manager signs it and creates the TLS Secret
→ api-syncagent syncs the Secret back to the consumer workspace

## Testing
Verified end-to-end from scratch using a local kind setup.
All commands run from the `resource-broker/` directory with `hack/lib.bash` sourced.
Two kind clusters are created: `broker-platform` (kcp + resource-broker) and `broker-cert-manager` (cert-manager + kro + api-syncagent).

**Prerequisites:** `kind`, `kubectl`, `helm`, `yq`, `go`, `openssl`, Docker running.

**Expected result:** `subject=CN=my-app.platform-mesh.io` in the consumer kcp workspace —
cert issued by cert-manager on the compute cluster, synced back via api-syncagent.

<details>
<summary>Full step-by-step commands</summary>

All commands run from `resource-broker/` directory. Source `hack/lib.bash` once at the start — it provides all the helper functions used throughout.

```bash
source hack/lib.bash
mkdir -p kubeconfigs/workspaces
```

---

**Step 0 — Clean up any existing clusters**

Removes leftover kind clusters from previous runs so we start with a clean slate. Skip if this is your first run.

```bash
for c in broker-platform broker-cert-manager; do
  kind delete cluster --name "$c" 2>/dev/null || true
done
```

---

**Step 1 — Fix the vendor directory**

There are some dependency updates. 

```bash
go mod vendor
```

---

**Step 2 — Create the platform kind cluster and export its kubeconfig**

The platform cluster hosts kcp (the control plane) and resource-broker. We create it with kind and export its kubeconfig so kubectl can talk to it.

```bash
kind::cluster platform kubeconfigs/platform.kubeconfig
kind export kubeconfig --name broker-platform --kubeconfig kubeconfigs/platform.kubeconfig
```

---

**Step 3 — Install platform components**

- **cert-manager**: needed by kcp to issue its own TLS certificates.
- **etcd-druid**: kcp uses etcd as its storage backend; etcd-druid manages the etcd cluster.
- **kcp**: the kcp control plane operator, which sets up the multi-workspace API server.

```bash
helm::install::certmanager kubeconfigs/platform.kubeconfig
helm::install::etcddruid kubeconfigs/platform.kubeconfig
helm::install::kcp kubeconfigs/platform.kubeconfig
```

---

**Step 4 — Deploy resource-broker-operator**

resource-broker-operator manages the broker deployment lifecycle. We load the pre-built image into kind (no registry needed) and apply its manifests.

```bash
make kind-load-operator KIND_CLUSTER=broker-platform
make deploy-operator KUBECONFIG=kubeconfigs/platform.kubeconfig
```

---

**Step 5 — Bootstrap kcp and create the platform workspace**

Applies the kcp bootstrap manifests (etcd cluster, front-proxy, root shard). Then waits for kcp to be ready and exports admin kubeconfigs. Finally creates `root:platform` — the workspace where the broker lives and where all APIExports are published.

```bash
kubectl::kustomize kubeconfigs/platform.kubeconfig ./examples/kcp-certs/platform
kcp::setup::kubeconfigs \
  kubeconfigs/platform.kubeconfig \
  kubeconfigs/kcp-admin.kubeconfig \
  kubeconfigs/kcp-from-host.kubeconfig
kcp::create_workspace \
  kubeconfigs/kcp-admin.kubeconfig \
  kubeconfigs/workspaces/platform.kubeconfig \
  platform
```

---

**Step 6 — Install broker CRDs and create APIExports in the platform workspace**

- Installs broker CRDs (`StagingWorkspace`, `Migration`, etc.) so the broker can persist its state inside kcp.
- Creates the **`acceptapis` APIExport** — providers bind this to declare which APIs they can serve.
- Creates the **`certificates` APIExport** for `identity.generic.platform-mesh.io/Certificate` — this is the generic API consumers bind to order certificates, independent of which provider backs it.

```bash
kubectl::apply kubeconfigs/workspaces/platform.kubeconfig \
  ./config/broker/crd/broker.platform-mesh.io_migrationconfigurations.yaml \
  ./config/broker/crd/broker.platform-mesh.io_migrations.yaml \
  ./config/broker/crd/broker.platform-mesh.io_stagingworkspaces.yaml

kcp::apiexport kubeconfigs/workspaces/platform.kubeconfig \
  ./config/broker/crd/broker.platform-mesh.io_acceptapis.yaml \
  secrets get,list,watch

kcp::apiexport kubeconfigs/workspaces/platform.kubeconfig \
  ./config/generic/crd/identity.generic.platform-mesh.io_certificates.yaml \
  secrets '*' events '*' namespaces '*'
```

---

**Step 7 — Create the cert-manager compute cluster and install cert-manager + kro**

The compute cluster is where the actual work happens — cert-manager signs certificates here and kro translates our generic `Certificate{fqdn}` into a real `cert-manager Certificate`. Completely separate from the platform cluster.

```bash
kind::cluster cert-manager kubeconfigs/cert-manager.kubeconfig
kind export kubeconfig --name broker-cert-manager --kubeconfig kubeconfigs/cert-manager.kubeconfig
helm::install::certmanager kubeconfigs/cert-manager.kubeconfig
helm::install::kro kubeconfigs/cert-manager.kubeconfig
```

---

**Step 8 — Apply our compute manifests (ClusterIssuer + KRO RGD)**

- **`issuer.yaml`**: creates a self-signed `ClusterIssuer` on the compute cluster. cert-manager uses this to sign certificates.
- **`rgd.yaml`**: a KRO `ResourceGraphDefinition` that defines the `certmanager.ca/Certificate` CRD and translates it into a real `cert-manager.io/Certificate`. When a `certmanager.ca/Certificate{fqdn}` is created, KRO creates the cert-manager Certificate pointing at our ClusterIssuer.

We wait for the RGD to become `Ready`, which means KRO has registered the `certmanager.ca/Certificate` CRD.

```bash
kubectl::kustomize kubeconfigs/cert-manager.kubeconfig ./examples/platform-mesh/cert-manager
kubectl::wait kubeconfigs/cert-manager.kubeconfig rgd/certificates.certmanager.ca "" condition=Ready
```

---

**Step 9 — Create the cert-manager kcp workspace and a minimal APIExport**

The provider workspace (`root:cert-manager`) is where the cert-manager provider lives inside kcp. We create a minimal (empty spec) `certificates` APIExport here — api-syncagent will fill in the schema automatically in the next step.

```bash
kcp::create_workspace \
  kubeconfigs/kcp-admin.kubeconfig \
  kubeconfigs/workspaces/cert-manager.kubeconfig \
  cert-manager

kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig \
  apply -f examples/platform-mesh/root:providers:cert-manager/apiexport.yaml
```

---

**Step 10 — Deploy api-syncagent on the compute cluster**

api-syncagent is the bridge between the compute cluster and kcp. It:
1. Watches the provider kcp workspace for `identity.generic.platform-mesh.io/Certificate` objects (placed there by resource-broker)
2. Creates corresponding `certmanager.ca/Certificate` objects on the compute cluster (picked up by KRO → cert-manager)
3. Syncs the resulting TLS `Secret` back up to the consumer workspace

We create a service account in the provider workspace, generate a kubeconfig for it, store it as a secret on the compute cluster, then deploy api-syncagent via Helm pointing at that secret.

```bash
api_syncagent_token="$(kcp::serviceaccount::admin \
  kubeconfigs/workspaces/cert-manager.kubeconfig api-syncagent default)"
kubeconfig::create::token kubeconfigs/api-syncagent-cert-manager.kubeconfig \
  "$(kubectl::kubeconfig::current_server_url kubeconfigs/workspaces/cert-manager.kubeconfig)" \
  "$api_syncagent_token"
kubectl::kubeconfig::secret kubeconfigs/cert-manager.kubeconfig \
  kubeconfigs/api-syncagent-cert-manager.kubeconfig \
  cert-manager default broker-platform-control-plane:32111

helm::install::api_syncagent kubeconfigs/cert-manager.kubeconfig \
  certificates cert-manager kubeconfig-cert-manager --set replicas=1
```

---

**Step 11 — Apply the PublishedResource**

`publishedresource.yaml` tells api-syncagent what to publish:
- **Local resource**: `certmanager.ca/Certificate` (created by KRO on the compute cluster)
- **Projected as**: `identity.generic.platform-mesh.io/Certificate` in kcp (the generic consumer-facing API)
- **Related resource**: the TLS `Secret` — api-syncagent syncs this back to the consumer workspace

```bash
kubectl --kubeconfig kubeconfigs/cert-manager.kubeconfig \
  apply -f examples/platform-mesh/cert-manager/publishedresource.yaml
```

---

**Step 12 — Wire up the provider workspace**

Wait for api-syncagent to automatically update the `certificates` APIExport with the `certmanager.ca` schema (projected as `identity.generic.platform-mesh.io`). Then:
- **Bind `acceptapis`** from the platform workspace — gives the provider workspace the `AcceptAPI` CRD so it can declare capabilities to resource-broker.
- **Apply `acceptapi.yaml`** — declares this provider handles `identity.generic.platform-mesh.io/certificates` with no filters (accepts all certificates). The `secret-name` annotation tells resource-broker which kubeconfig to use when routing to this provider.
- **Bind the local `certificates` APIExport** back into the provider workspace — makes `identity.generic.platform-mesh.io/Certificate` available locally so api-syncagent and resource-broker can use it.

```bash
# Wait for api-syncagent to update the APIExport schema
until kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig \
  get apiexport certificates -o jsonpath='{.spec.resources}' 2>/dev/null \
  | grep -q "identity"; do sleep 3; done

# Bind acceptapis from platform workspace
kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig apply -f- <<EOF
apiVersion: apis.kcp.io/v1alpha2
kind: APIBinding
metadata:
  name: acceptapis
spec:
  reference:
    export:
      path: root:platform
      name: acceptapis
  permissionClaims:
    - resource: secrets
      group: ''
      state: Accepted
      verbs: ['get','list','watch']
      selector:
        matchAll: true
EOF
kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig \
  wait --for=condition=Ready apibinding/acceptapis --timeout=60s

# Declare provider capabilities to resource-broker
kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig \
  apply -f examples/platform-mesh/root:providers:cert-manager/acceptapi.yaml

# Bind the provider's own APIExport locally
kcp::apibinding kubeconfigs/workspaces/cert-manager.kubeconfig "root:cert-manager" certificates \
  secrets "" '*' events "" '*' namespaces "" '*'
```

---

**Step 13 — Create the VW kubeconfig for resource-broker and the consumer workspace**

resource-broker needs a kubeconfig pointing at the provider's Virtual Workspace (VW) endpoint — this is how it writes routed certificates into the provider workspace. We store it as a secret in the provider workspace so the broker can find it via the `secret-name` annotation on the `AcceptAPI`.

We also create `root:consumer` — the workspace that represents an end-user/tenant.

```bash
cluster_id=$(kubectl --kubeconfig kubeconfigs/workspaces/cert-manager.kubeconfig \
  get apiexportendpointslices/certificates \
  -o jsonpath='{.metadata.annotations.kcp\.io/cluster}')
endpoint_url="https://broker-platform-control-plane:32443/services/apiexport/$cluster_id/certificates/clusters/$cluster_id"
sa_token="$(kcp::serviceaccount::admin \
  kubeconfigs/workspaces/cert-manager.kubeconfig broker default)"
kubeconfig::create::token \
  kubeconfigs/workspaces/cert-manager.vw.kubeconfig "$endpoint_url" "$sa_token"
kubectl::kubeconfig::secret kubeconfigs/workspaces/cert-manager.kubeconfig \
  kubeconfigs/workspaces/cert-manager.vw.kubeconfig \
  cert-manager default broker-platform-control-plane:32443

kcp::create_workspace \
  kubeconfigs/kcp-admin.kubeconfig \
  kubeconfigs/workspaces/consumer.kubeconfig \
  consumer
```

---

**Step 14 — Build and start resource-broker**

resource-broker is the routing layer — it watches consumer workspaces for `identity.generic.platform-mesh.io/Certificate` objects, finds a matching provider via `AcceptAPI`, and routes the certificate to that provider's VW. We use `sed` to set the watch-kind to `identity.generic.platform-mesh.io` instead of the default `example.platform-mesh.io`.

```bash
make kind-load-kcp KIND_CLUSTER=broker-platform

kubectl --kubeconfig kubeconfigs/platform.kubeconfig \
  get secret operator-kubeconfig \
  -o jsonpath='{.data.kubeconfig}' | base64 -d > kubeconfigs/operator.kubeconfig
yq -i '(.clusters[] | select(.name=="default") | .cluster.server) += ":platform"' \
  kubeconfigs/operator.kubeconfig

kubectl create secret generic kcp-kubeconfig \
  --namespace=resource-broker-system \
  --dry-run=client -o yaml \
  --from-file=kubeconfig=kubeconfigs/operator.kubeconfig \
  | kubectl --kubeconfig kubeconfigs/platform.kubeconfig apply -f-

cat examples/kcp-certs/platform/broker.yaml \
  | sed 's|Certificate.v1alpha1.example.platform-mesh.io|Certificate.v1alpha1.identity.generic.platform-mesh.io|' \
  | kubectl --kubeconfig kubeconfigs/platform.kubeconfig apply -f-

kubectl --kubeconfig kubeconfigs/platform.kubeconfig \
  wait broker/resource-broker -n resource-broker-system \
  --for=condition=Available --timeout=60s
```

---

**Step 15 — Consumer binds the Certificate API**

The consumer workspace doesn't have `identity.generic.platform-mesh.io/Certificate` by default — it needs to explicitly bind the `certificates` APIExport from the platform workspace. After this, the consumer can create Certificate resources.

```bash
kcp::apibinding kubeconfigs/workspaces/consumer.kubeconfig "root:platform" certificates \
  secrets "" '*' events "" '*' namespaces "" '*'
```

---

**Step 16 — Consumer orders a Certificate**

The consumer creates a `Certificate` with just the `fqdn` they want. resource-broker picks it up, routes it to the cert-manager provider, KRO translates it to a cert-manager Certificate, cert-manager signs it, and api-syncagent syncs the TLS Secret back.

```bash
kubectl --kubeconfig kubeconfigs/workspaces/consumer.kubeconfig apply -f- <<EOF
apiVersion: identity.generic.platform-mesh.io/v1alpha1
kind: Certificate
metadata:
  name: cert-from-consumer
  namespace: default
spec:
  fqdn: my-app.platform-mesh.io
EOF
```

---

**Step 17 — Verify the full flow**

Wait for the TLS Secret to appear in the consumer workspace (api-syncagent syncs it back from the compute cluster), then confirm the certificate was issued for the right FQDN.

```bash
kubectl --kubeconfig kubeconfigs/workspaces/consumer.kubeconfig \
  wait secret/cert-from-consumer --for=create --timeout=5m

kubectl --kubeconfig kubeconfigs/workspaces/consumer.kubeconfig \
  get secret cert-from-consumer \
  -o jsonpath="{.data.tls\.crt}" | base64 -d | openssl x509 -noout -subject
# Expected: subject=CN=my-app.platform-mesh.io
```

</details>